### PR TITLE
Inability to generate a cache object, does not pass. No need to throttle

### DIFF
--- a/javascript/src/main/resources/javascript/ManifestationInfo.use.js
+++ b/javascript/src/main/resources/javascript/ManifestationInfo.use.js
@@ -90,7 +90,7 @@ var ManifestationInfo = (function() {
 
         if ( "" === title ) {
             RecordProcessing.terminateProcessingAndFailRecord(
-                "ManifestationInfo.getFullTitle no full title was found in local or common stream" );
+                "ManifestationInfo.getTitle title was found in local or common stream" );
         }
 
         Log.trace( "Leaving: ManifestationInfo.getTitle function" );

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <corepo.version>1.2-SNAPSHOT</corepo.version>
-        <pgqueue.version>1.3-SNAPSHOT</pgqueue.version>
+        <pgqueue.version>1.4-SNAPSHOT</pgqueue.version>
         <jslib.version>1.3-SNAPSHOT</jslib.version>
         <jscommon.version>2012.1-SNAPSHOT</jscommon.version>
         <solr.version>8.6.2</solr.version>

--- a/worker/src/main/java/dk/dbc/search/work/presentation/worker/tree/NoCacheObjectException.java
+++ b/worker/src/main/java/dk/dbc/search/work/presentation/worker/tree/NoCacheObjectException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 DBC A/S (http://dbc.dk/)
+ *
+ * This is part of work-presentation-worker
+ *
+ * work-presentation-worker is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * work-presentation-worker is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package dk.dbc.search.work.presentation.worker.tree;
+
+/**
+ *
+ * @author Morten Bøgeskov (mb@dbc.dk)
+ */
+public class NoCacheObjectException extends RuntimeException {
+
+    private static final long serialVersionUID = 0x8A7C92A34ACAB1DAL;
+
+    public NoCacheObjectException(String string) {
+        super(string);
+    }
+}


### PR DESCRIPTION
Special Exception if nothing is available in the cache, after cache objects are generated.
Use pg-queue 1.4 "No-Throttle" Exception