### PR TITLE
Make the beanfactory autoclosable for cleanup (calling @PreDestroy)

### DIFF
--- a/api/src/test/java/dk/dbc/search/work/presentation/api/jpa/JpaBase.java
+++ b/api/src/test/java/dk/dbc/search/work/presentation/api/jpa/JpaBase.java
@@ -54,7 +54,7 @@ import static org.eclipse.persistence.config.PersistenceUnitProperties.JDBC_USER
  * @param <BF> a beanFactory as produced by
  *             {@link #createBeanFactory(java.util.Map, javax.persistence.EntityManager)}
  */
-public abstract class JpaBase<BF> {
+public abstract class JpaBase<BF extends AutoCloseable> {
 
     private static final Logger log = LoggerFactory.getLogger(JpaBase.class);
 
@@ -153,7 +153,11 @@ public abstract class JpaBase<BF> {
         }
 
         public void jpaWithBeans(JpaBeanVoidExecution<BF> execution) {
-            jpa(em -> execution.execute(createBeanFactory(env, em)));
+            jpa(em -> {
+                try (BF bf = createBeanFactory(env, em)) {
+                    execution.execute(bf);
+                }
+            });
         }
     }
 

--- a/api/src/test/java/dk/dbc/search/work/presentation/api/jpa/RecordEntityIT.java
+++ b/api/src/test/java/dk/dbc/search/work/presentation/api/jpa/RecordEntityIT.java
@@ -39,7 +39,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  *
  * @author Morten Bøgeskov (mb@dbc.dk)
  */
-public class RecordEntityIT extends JpaBase<Object> {
+public class RecordEntityIT extends JpaBase<AutoCloseable> {
 
     public RecordEntityIT() {
     }
@@ -115,8 +115,9 @@ public class RecordEntityIT extends JpaBase<Object> {
     }
 
     @Override
-    public Object createBeanFactory(Map<String, String> env, EntityManager em) {
-        throw new UnsupportedOperationException("Not supported yet.");
+    public AutoCloseable createBeanFactory(Map<String, String> env, EntityManager em) {
+        return () -> {
+        };
     }
 
 }

--- a/api/src/test/java/dk/dbc/search/work/presentation/api/jpa/WorkContainsEntityIT.java
+++ b/api/src/test/java/dk/dbc/search/work/presentation/api/jpa/WorkContainsEntityIT.java
@@ -32,7 +32,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  *
  * @author Morten Bøgeskov (mb@dbc.dk)
  */
-public class WorkContainsEntityIT extends JpaBase<Object> {
+public class WorkContainsEntityIT extends JpaBase<AutoCloseable> {
 
     @Test
     public void saveMultiple() throws Exception {
@@ -75,8 +75,9 @@ public class WorkContainsEntityIT extends JpaBase<Object> {
     }
 
     @Override
-    public Object createBeanFactory(Map<String, String> env, EntityManager em) {
-        throw new UnsupportedOperationException("Not supported yet.");
+    public AutoCloseable createBeanFactory(Map<String, String> env, EntityManager em) {
+        return () -> {
+        };
     }
 
 }

--- a/service/src/test/java/dk/dbc/search/work/presentation/service/BeanFactory.java
+++ b/service/src/test/java/dk/dbc/search/work/presentation/service/BeanFactory.java
@@ -34,7 +34,7 @@ import org.glassfish.jersey.client.JerseyClientBuilder;
  *
  * @author Morten Bøgeskov (mb@dbc.dk)
  */
-public class BeanFactory {
+public class BeanFactory implements AutoCloseable {
 
     private final EntityManager em;
     private final DataSource dataSource;
@@ -49,6 +49,10 @@ public class BeanFactory {
         this.em = em;
         this.dataSource = dataSource;
         this.config = makeConfig(envs);
+    }
+
+    @Override
+    public void close() throws Exception {
     }
 
     private static Config makeConfig(Map<String, String> envs) {

--- a/worker/src/test/java/dk/dbc/search/work/presentation/worker/BeanFactory.java
+++ b/worker/src/test/java/dk/dbc/search/work/presentation/worker/BeanFactory.java
@@ -18,6 +18,7 @@
  */
 package dk.dbc.search.work.presentation.worker;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,7 +34,7 @@ import org.glassfish.jersey.client.JerseyClientBuilder;
  *
  * @author Morten Bøgeskov (mb@dbc.dk)
  */
-public class BeanFactory {
+public class BeanFactory implements AutoCloseable {
 
     private final EntityManager entityManager;
     private final DataSource corepoDataSource;
@@ -45,11 +46,17 @@ public class BeanFactory {
     private final Bean<WorkConsolidator> workConsolidator = new Bean<>(new WorkConsolidator(), this::setupWorkConsolidator);
     private final Bean<Worker> worker = new Bean<>(new Worker(), this::setupWorker);
     private final Bean<WorkTreeBuilder> workTreeBuilder = new Bean<>(new WorkTreeBuilder(), this::setupWorkTreeBuilder);
+    private final ArrayList<Runnable> cleanup = new ArrayList<>();
 
     public BeanFactory(Map<String, String> envs, EntityManager em, DataSource corepoDataSource) {
         this.entityManager = em;
         this.corepoDataSource = corepoDataSource;
         this.config = makeConfig(envs);
+    }
+
+    @Override
+    public void close() throws Exception {
+        cleanup.forEach(Runnable::run);
     }
 
     private static Config makeConfig(Map<String, String> envs) {


### PR DESCRIPTION
Allow for cleanup when running a .jpaWithBeans(beanFactory -> {}), by utilizing AutoClosable