### PR TITLE
DI-58 workTypes from primary in response

### DIFF
--- a/api/src/main/java/dk/dbc/search/work/presentation/api/pojo/ManifestationInformation.java
+++ b/api/src/main/java/dk/dbc/search/work/presentation/api/pojo/ManifestationInformation.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ManifestationInformation implements Serializable {
 
-    private static final long serialVersionUID = 0x644CAC76C6A06754L;
+    private static final long serialVersionUID = 0x7E0D20E1E0394E01L;
 
     @JsonProperty("pid")
     public String manifestationId;

--- a/api/src/main/java/dk/dbc/search/work/presentation/api/pojo/ManifestationInformation.java
+++ b/api/src/main/java/dk/dbc/search/work/presentation/api/pojo/ManifestationInformation.java
@@ -34,6 +34,8 @@ public class ManifestationInformation implements Serializable {
     @JsonProperty("types")
     public List<String> materialTypes;
 
+    public List<String> workTypes;
+
     @JsonProperty()
     public Map<String, String> priorityKeys;
 
@@ -52,12 +54,13 @@ public class ManifestationInformation implements Serializable {
                Objects.equals(description, that.description) &&
                Objects.equals(subjects, that.subjects) &&
                Objects.equals(materialTypes, that.materialTypes) &&
+               Objects.equals(workTypes, that.workTypes) &&
                Objects.equals(priorityKeys, that.priorityKeys);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(manifestationId, title, fullTitle, series, creators, description, subjects, materialTypes, priorityKeys);
+        return Objects.hash(manifestationId, title, fullTitle, series, creators, description, subjects, materialTypes, workTypes, priorityKeys);
     }
 
     @Override
@@ -71,6 +74,7 @@ public class ManifestationInformation implements Serializable {
                ", description='" + description + '\'' +
                ", subjects=" + subjects +
                ", types=" + materialTypes +
+               ", workTypes=" + workTypes +
                ", priorityKeys=" + priorityKeys +
                '}';
     }
@@ -79,6 +83,7 @@ public class ManifestationInformation implements Serializable {
         ManifestationInformation res = new ManifestationInformation();
         res.manifestationId = this.manifestationId;
         res.materialTypes = this.materialTypes;
+        res.workTypes = this.workTypes;
         return res;
     }
 }

--- a/api/src/main/java/dk/dbc/search/work/presentation/api/pojo/WorkInformation.java
+++ b/api/src/main/java/dk/dbc/search/work/presentation/api/pojo/WorkInformation.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -11,7 +12,7 @@ import java.util.Set;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class WorkInformation implements Serializable {
 
-    private static final long serialVersionUID = 0x3B56D3505757B617L;
+    private static final long serialVersionUID = 0x3DBBAFB032227F85L;
 
     public String workId;
 
@@ -26,6 +27,8 @@ public class WorkInformation implements Serializable {
     public String description;
 
     public Set<TypedValue> subjects;
+
+    public List<String> workTypes;
 
     @JsonProperty("dbUnits")
     // Unit -> Manifestations
@@ -51,6 +54,7 @@ public class WorkInformation implements Serializable {
                Objects.equals(creators, that.creators) &&
                Objects.equals(description, that.description) &&
                Objects.equals(subjects, that.subjects) &&
+               Objects.equals(workTypes, that.workTypes) &&
                Objects.equals(dbUnitInformation, that.dbUnitInformation) &&
                Objects.equals(ownerUnitId, that.ownerUnitId) &&
                Objects.equals(dbRelUnitInformation, that.dbRelUnitInformation);
@@ -58,7 +62,7 @@ public class WorkInformation implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(workId, title, fullTitle, series, creators, description, subjects, dbUnitInformation, ownerUnitId, dbRelUnitInformation);
+        return Objects.hash(workId, title, fullTitle, series, creators, description, subjects, workTypes, dbUnitInformation, ownerUnitId, dbRelUnitInformation);
     }
 
     @Override
@@ -72,6 +76,7 @@ public class WorkInformation implements Serializable {
                ", creators='" + creators + '\'' +
                ", description='" + description + '\'' +
                ", subjects='" + subjects + '\'' +
+               ", workTypes='" + workTypes + '\'' +
                ", dbUnitInformation=" + dbUnitInformation +
                ", relUnitTypeInformation=" + dbRelUnitInformation +
                '}';

--- a/javascript/src/main/resources/javascript/ManifestationInfo.test.js
+++ b/javascript/src/main/resources/javascript/ManifestationInfo.test.js
@@ -118,6 +118,7 @@ UnitTest.addFixture( "ManifestationInfo.getManifestationInfoFromXmlObjects", fun
             "description": null, //from commonData stream dcterms:abstract - string, null if no data
             "subjects": [], //from dc stream if subject element present, array, empty array if no data
             "types": [ "Bog" ], //from DC stream, array, most be present
+            "workTypes": [ "literature" ], //from commonData stream adminData workType, array, must be present
             "priorityKeys": { //from DC stream for determining owner of the work, must be present
                 "identifier": "08021473|870970",
                 "date": "1972",
@@ -144,6 +145,7 @@ UnitTest.addFixture( "ManifestationInfo.getManifestationInfoFromXmlObjects", fun
             "description": null,
             "subjects": [],
             "types": [ "Bog" ],
+            "workTypes": [ "literature" ],
             "priorityKeys": {
                 "identifier": "08021473|870970",
                 "date": "1972",
@@ -1955,5 +1957,131 @@ UnitTest.addFixture( "ManifestationInfo.getPriorityKeys", function() {
     };
 
     Assert.equalValue( "get priority-keys from local before common stream ", ManifestationInfo.getPriorityKeys( commonData, localData ), expected );
+
+} );
+
+
+UnitTest.addFixture( "ManifestationInfo.getWorkTypes", function() {
+
+    var commonDataString =
+        '<ting:container ' +
+        'xmlns:ting="http://www.dbc.dk/ting" ' +
+        'xmlns:ac="http://biblstandard.dk/ac/namespace/" ' +
+        'xmlns:dc="http://purl.org/dc/elements/1.1/" ' +
+        'xmlns:dcterms="http://purl.org/dc/terms/" ' +
+        'xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/" ' +
+        'xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/" ' +
+        'xmlns:docbook="http://docbook.org/ns/docbook" ' +
+        'xmlns:oss="http://oss.dbc.dk/ns/osstypes" ' +
+        'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"> ' +
+        '<dkabm:record>' +
+        '<ac:identifier>23645564|870970</ac:identifier>' +
+        '<ac:source>Bibliotekskatalog</ac:source>' +
+        '<dc:title>Trækopfuglens krønike</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Trækopfuglens krønike</dc:title>' +
+        '</dkabm:record>' +
+        '<adminData>' +
+        '<recordStatus>active</recordStatus>' +
+        '<creationDate>2016-07-09</creationDate>' +
+        '<libraryType>none</libraryType>' +
+        '<genre>fiktion</genre>' +
+        '<indexingAlias>danmarcxchange</indexingAlias>' +
+        '<accessType>physical</accessType>' +
+        '<workType>literature</workType>' +
+        '<collectionIdentifier>870970-basis</collectionIdentifier>' +
+        '<collectionIdentifier>870970-danbib</collectionIdentifier>' +
+        '<collectionIdentifier>870970-bibdk</collectionIdentifier>' +
+        '</adminData>' +
+        '</ting:container>'
+    var commonData = XmlUtil.fromString( commonDataString );
+
+    var expected = [ "literature" ];
+
+    Assert.equalValue( "get workType from adminData", ManifestationInfo.getWorkTypes( commonData ), expected );
+
+    commonDataString =
+        '<ting:container ' +
+        'xmlns:ting="http://www.dbc.dk/ting" ' +
+        'xmlns:ac="http://biblstandard.dk/ac/namespace/" ' +
+        'xmlns:dc="http://purl.org/dc/elements/1.1/" ' +
+        'xmlns:dcterms="http://purl.org/dc/terms/" ' +
+        'xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/" ' +
+        'xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/" ' +
+        'xmlns:docbook="http://docbook.org/ns/docbook" ' +
+        'xmlns:oss="http://oss.dbc.dk/ns/osstypes" ' +
+        'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"> ' +
+        '<dkabm:record>' +
+        '<ac:identifier>52780128|870970</ac:identifier>' +
+        '<ac:source>Bibliotekskatalog</ac:source>' +
+        '<dc:title>Styr på dyr. Sebastians vildeste hits</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Styr på dyr. Sebastians vildeste hits</dc:title>' +
+        '</dkabm:record>' +
+        '<adminData>' +
+        '<recordStatus>active</recordStatus>' +
+        '<creationDate>2016-11-24</creationDate>' +
+        '<libraryType>none</libraryType>' +
+        '<indexingAlias>danmarcxchange</indexingAlias>' +
+        '<accessType>physical</accessType>' +
+        '<workType>literature</workType>' +
+        '<workType>music</workType>' +
+        '<collectionIdentifier>870970-basis</collectionIdentifier>' +
+        '<collectionIdentifier>870970-danbib</collectionIdentifier>' +
+        '<collectionIdentifier>870970-bibdk</collectionIdentifier>' +
+        '</adminData>' +
+        '</ting:container>'
+
+    commonData = XmlUtil.fromString( commonDataString );
+
+    expected = [ "literature", "music" ];
+
+    Assert.equalValue( "get multiple workTypes from adminData ", ManifestationInfo.getWorkTypes( commonData ), expected );
+
+    commonDataString =
+        '<ting:container ' +
+        'xmlns:ting="http://www.dbc.dk/ting" ' +
+        'xmlns:ac="http://biblstandard.dk/ac/namespace/" ' +
+        'xmlns:dc="http://purl.org/dc/elements/1.1/" ' +
+        'xmlns:dcterms="http://purl.org/dc/terms/" ' +
+        'xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/" ' +
+        'xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/" ' +
+        'xmlns:docbook="http://docbook.org/ns/docbook" ' +
+        'xmlns:oss="http://oss.dbc.dk/ns/osstypes" ' +
+        'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"> ' +
+        '<dkabm:record>' +
+        '<ac:identifier>51349016|870970</ac:identifier>' +
+        '<ac:source>Bibliotekernes podcasts</ac:source>' +
+        '<dc:title>Podcast: "Den danske borgerkrig 2018-24" af Kaspar Colling-Nielsen</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Podcast: "Den danske borgerkrig 2018-24" af Kaspar Colling-Nielsen</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:series">Månedens bog - podcast</dc:title>' +
+        '</dkabm:record>' +
+        '<adminData>' +
+        '<recordStatus>active</recordStatus>' +
+        '<creationDate>2016-07-09</creationDate>' +
+        '<libraryType>none</libraryType>' +
+        '<genre>nonfiktion</genre>' +
+        '<indexingAlias>danmarcxchange</indexingAlias>' +
+        '<accessType>online</accessType>' +
+        '<workType>none</workType>' +
+        '<collectionIdentifier>870970-basis</collectionIdentifier>' +
+        '<collectionIdentifier>870970-danbib</collectionIdentifier>' +
+        '<collectionIdentifier>870970-bibdk</collectionIdentifier>' +
+        '<collectionIdentifier>870970-netbkm</collectionIdentifier>' +
+        '<collectionIdentifier>150080-bibcast</collectionIdentifier>' +
+        '</adminData>' +
+        '</ting:container>'
+
+    commonData = XmlUtil.fromString( commonDataString );
+
+    expected = [ "none" ];
+
+    Assert.equalValue( "get workType none from adminData ", ManifestationInfo.getWorkTypes( commonData ), expected );
+
+    commonDataString = '<empty/>';
+
+    commonData = XmlUtil.fromString( commonDataString );
+
+    Assert.exception( "Stop processing if commonData has no workType", function() {
+        ManifestationInfo.getWorkTypes( commonData );
+    }, Packages.dk.dbc.javascript.recordprocessing.FailRecord );
 
 } );

--- a/javascript/src/main/resources/javascript/ManifestationInfo.test.js
+++ b/javascript/src/main/resources/javascript/ManifestationInfo.test.js
@@ -169,98 +169,98 @@ UnitTest.addFixture( "ManifestationInfo.getTitle", function() {
 
     var commonDataString = '<empty/>';
     var localDataString =
-            '<ting:localData' +
-            ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
-            ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-            ' xmlns:dcterms="http://purl.org/dc/terms/"' +
-            ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
-            ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
-            ' xmlns:docbook="http://docbook.org/ns/docbook"' +
-            ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
-            ' xmlns:ting="http://www.dbc.dk/ting"' +
-            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dkabm:record>' +
-            '<ac:identifier>22023578|870970</ac:identifier>' +
-            '<ac:source>Bibliotekskatalog</ac:source>' +
-            '<dc:title>Ave Femina!</dc:title>' +
-            '<dc:title xsi:type="dkdcplus:full">Ave Femina! : Digte</dc:title>' +
-            '</dkabm:record>' +
-            '</ting:localData>';
+        '<ting:localData' +
+        ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:dcterms="http://purl.org/dc/terms/"' +
+        ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
+        ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
+        ' xmlns:docbook="http://docbook.org/ns/docbook"' +
+        ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
+        ' xmlns:ting="http://www.dbc.dk/ting"' +
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+        '<dkabm:record>' +
+        '<ac:identifier>22023578|870970</ac:identifier>' +
+        '<ac:source>Bibliotekskatalog</ac:source>' +
+        '<dc:title>Ave Femina!</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Ave Femina! : Digte</dc:title>' +
+        '</dkabm:record>' +
+        '</ting:localData>';
 
-    var localData = XmlUtil.fromString(localDataString);
-    var commonData = XmlUtil.fromString(commonDataString);
+    var localData = XmlUtil.fromString( localDataString );
+    var commonData = XmlUtil.fromString( commonDataString );
 
     var expected = "Ave Femina!";
 
     Assert.equalValue( "get title from localData ", ManifestationInfo.getTitle( commonData, localData ), expected );
 
     commonDataString =
-            '<ting:container' +
-            ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
-            ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-            ' xmlns:dcterms="http://purl.org/dc/terms/"' +
-            ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
-            ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
-            ' xmlns:docbook="http://docbook.org/ns/docbook"' +
-            ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
-            ' xmlns:ting="http://www.dbc.dk/ting"' +
-            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dkabm:record>' +
-            '<ac:identifier>22023578|870970</ac:identifier>' +
-            '<ac:source>Bibliotekskatalog</ac:source>' +
-            '<dc:title>Ave Femina!</dc:title>' +
-            '<dc:title xsi:type="dkdcplus:full">Ave Femina! : Digte</dc:title>' +
-            '</dkabm:record>' +
-            '</ting:container>';
+        '<ting:container' +
+        ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:dcterms="http://purl.org/dc/terms/"' +
+        ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
+        ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
+        ' xmlns:docbook="http://docbook.org/ns/docbook"' +
+        ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
+        ' xmlns:ting="http://www.dbc.dk/ting"' +
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+        '<dkabm:record>' +
+        '<ac:identifier>22023578|870970</ac:identifier>' +
+        '<ac:source>Bibliotekskatalog</ac:source>' +
+        '<dc:title>Ave Femina!</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Ave Femina! : Digte</dc:title>' +
+        '</dkabm:record>' +
+        '</ting:container>';
     localDataString = '<empty/>';
 
-    localData = XmlUtil.fromString(localDataString);
-    commonData = XmlUtil.fromString(commonDataString);
+    localData = XmlUtil.fromString( localDataString );
+    commonData = XmlUtil.fromString( commonDataString );
 
     expected = "Ave Femina!";
 
     Assert.equalValue( "get title from commonData ", ManifestationInfo.getTitle( commonData, localData ), expected );
 
     commonDataString =
-            '<ting:container' +
-            ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
-            ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-            ' xmlns:dcterms="http://purl.org/dc/terms/"' +
-            ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
-            ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
-            ' xmlns:docbook="http://docbook.org/ns/docbook"' +
-            ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
-            ' xmlns:ting="http://www.dbc.dk/ting"' +
-            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dkabm:record>' +
-            '<ac:identifier>22023578|870970</ac:identifier>' +
-            '<ac:source>Bibliotekskatalog</ac:source>' +
-            '<dc:title>Ave Femina! - not this one</dc:title>' +
-            '<dc:title xsi:type="dkdcplus:full">Ave Femina! : Digte</dc:title>' +
-            '</dkabm:record>' +
-            '</ting:container>';
+        '<ting:container' +
+        ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:dcterms="http://purl.org/dc/terms/"' +
+        ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
+        ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
+        ' xmlns:docbook="http://docbook.org/ns/docbook"' +
+        ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
+        ' xmlns:ting="http://www.dbc.dk/ting"' +
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+        '<dkabm:record>' +
+        '<ac:identifier>22023578|870970</ac:identifier>' +
+        '<ac:source>Bibliotekskatalog</ac:source>' +
+        '<dc:title>Ave Femina! - not this one</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Ave Femina! : Digte</dc:title>' +
+        '</dkabm:record>' +
+        '</ting:container>';
 
     localDataString =
-            '<ting:localData' +
-            ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
-            ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-            ' xmlns:dcterms="http://purl.org/dc/terms/"' +
-            ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
-            ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
-            ' xmlns:docbook="http://docbook.org/ns/docbook"' +
-            ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
-            ' xmlns:ting="http://www.dbc.dk/ting"' +
-            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dkabm:record>' +
-            '<ac:identifier>22023578|870970</ac:identifier>' +
-            '<ac:source>Bibliotekskatalog</ac:source>' +
-            '<dc:title>Ave Femina!</dc:title>' +
-            '<dc:title xsi:type="dkdcplus:full">Ave Femina! : Digte</dc:title>' +
-            '</dkabm:record>' +
-            '</ting:localData>';
+        '<ting:localData' +
+        ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:dcterms="http://purl.org/dc/terms/"' +
+        ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
+        ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
+        ' xmlns:docbook="http://docbook.org/ns/docbook"' +
+        ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
+        ' xmlns:ting="http://www.dbc.dk/ting"' +
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+        '<dkabm:record>' +
+        '<ac:identifier>22023578|870970</ac:identifier>' +
+        '<ac:source>Bibliotekskatalog</ac:source>' +
+        '<dc:title>Ave Femina!</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Ave Femina! : Digte</dc:title>' +
+        '</dkabm:record>' +
+        '</ting:localData>';
 
-    localData = XmlUtil.fromString(localDataString);
-    commonData = XmlUtil.fromString(commonDataString);
+    localData = XmlUtil.fromString( localDataString );
+    commonData = XmlUtil.fromString( commonDataString );
 
     expected = "Ave Femina!";
 
@@ -268,26 +268,26 @@ UnitTest.addFixture( "ManifestationInfo.getTitle", function() {
 
     commonDataString = '<empty/>';
     localDataString =
-            '<ting:localData' +
-            ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
-            ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-            ' xmlns:dcterms="http://purl.org/dc/terms/"' +
-            ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
-            ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
-            ' xmlns:docbook="http://docbook.org/ns/docbook"' +
-            ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
-            ' xmlns:ting="http://www.dbc.dk/ting"' +
-            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dkabm:record>' +
-            '<ac:identifier>22023578|870970</ac:identifier>' +
-            '<ac:source>Bibliotekskatalog</ac:source>' +
-/*  TITLE NOT PRESENT '<dc:title>Ave Femina!</dc:title>' + */
-            '<dc:title xsi:type="dkdcplus:full">Ave Femina! : Digte</dc:title>' +
-            '</dkabm:record>' +
-            '</ting:localData>';
+        '<ting:localData' +
+        ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:dcterms="http://purl.org/dc/terms/"' +
+        ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
+        ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
+        ' xmlns:docbook="http://docbook.org/ns/docbook"' +
+        ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
+        ' xmlns:ting="http://www.dbc.dk/ting"' +
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+        '<dkabm:record>' +
+        '<ac:identifier>22023578|870970</ac:identifier>' +
+        '<ac:source>Bibliotekskatalog</ac:source>' +
+        /*  TITLE NOT PRESENT '<dc:title>Ave Femina!</dc:title>' + */
+        '<dc:title xsi:type="dkdcplus:full">Ave Femina! : Digte</dc:title>' +
+        '</dkabm:record>' +
+        '</ting:localData>';
 
-    localData = XmlUtil.fromString(localDataString);
-    commonData = XmlUtil.fromString(commonDataString);
+    localData = XmlUtil.fromString( localDataString );
+    commonData = XmlUtil.fromString( commonDataString );
 
     Assert.exception( "Stop processing if dc has no title", function() {
         ManifestationInfo.getTitle( commonData, localData );
@@ -345,7 +345,7 @@ UnitTest.addFixture( "ManifestationInfo.getFullTitle", function() {
 
     Assert.equalValue( "get full title from common data", ManifestationInfo.getFullTitle( commonData, localData ), expected );
 
-    var commonDataString =
+    commonDataString =
         '<ting:container ' +
         'xmlns:ac="http://biblstandard.dk/ac/namespace/" ' +
         'xmlns:dc="http://purl.org/dc/elements/1.1/" ' +
@@ -361,7 +361,7 @@ UnitTest.addFixture( "ManifestationInfo.getFullTitle", function() {
         '</dkabm:record>' +
         '</ting:container>';
 
-    var localDataString =
+    localDataString =
         '<ting:localData ' +
         'xmlns:marcx="info:lc/xmlns/marcxchange-v1" ' +
         'xmlns:ting="http://www.dbc.dk/ting">' +
@@ -372,10 +372,10 @@ UnitTest.addFixture( "ManifestationInfo.getFullTitle", function() {
         '</marcx:record>' +
         '</ting:localData>';
 
-    var commonData = XmlUtil.fromString( commonDataString );
-    var localData = XmlUtil.fromString( localDataString );
+    commonData = XmlUtil.fromString( commonDataString );
+    localData = XmlUtil.fromString( localDataString );
 
-    var expected = "Værkstedstekniske beregninger. M2, Boring";
+    expected = "Værkstedstekniske beregninger. M2, Boring";
 
     Assert.equalValue( "get full title from common data with whitespace ", ManifestationInfo.getFullTitle( commonData, localData ), expected );
 
@@ -645,8 +645,8 @@ UnitTest.addFixture( "ManifestationInfo.getSeries", function() {
     Assert.equalValue( "get series title from localData ", ManifestationInfo.getSeries( commonData, localData ), expected );
 
 
-    var commonDataString = '<empty/>';
-    var localDataString =
+    commonDataString = '<empty/>';
+    localDataString =
         '<ting:localData' +
         ' xmlns:ting="http://www.dbc.dk/ting"' +
         ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
@@ -668,10 +668,10 @@ UnitTest.addFixture( "ManifestationInfo.getSeries", function() {
         '</ting:localData>';
 
 
-    var commonData = XmlUtil.fromString( commonDataString );
-    var localData = XmlUtil.fromString( localDataString );
+    commonData = XmlUtil.fromString( commonDataString );
+    localData = XmlUtil.fromString( localDataString );
 
-    var expected = {
+    expected = {
         "title": "2. del af: Harry Potter og De Vises Sten ; woot-woot",
         "instalment": null
     };
@@ -679,7 +679,7 @@ UnitTest.addFixture( "ManifestationInfo.getSeries", function() {
     Assert.equalValue( "get series description from localData not split by ';' ", ManifestationInfo.getSeries( commonData, localData ), expected );
 
 
-    var commonDataString =
+    commonDataString =
         '<ting:container' +
         ' xmlns:ting="http://www.dbc.dk/ting"' +
         ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
@@ -700,12 +700,12 @@ UnitTest.addFixture( "ManifestationInfo.getSeries", function() {
         '<dc:creator xsi:type="oss:sort">Bøgh Andersen, Kenneth</dc:creator>' +
         '</dkabm:record>' +
         '</ting:container>';
-    var localDataString = '<empty/>';
-        
-    var commonData = XmlUtil.fromString( commonDataString );
-    var localData = XmlUtil.fromString( localDataString );
+    localDataString = '<empty/>';
 
-    var expected = {
+    commonData = XmlUtil.fromString( commonDataString );
+    localData = XmlUtil.fromString( localDataString );
+
+    expected = {
         "title": "Den store djævlekrig",
         "instalment": "1"
     };
@@ -713,7 +713,7 @@ UnitTest.addFixture( "ManifestationInfo.getSeries", function() {
     Assert.equalValue( "get series title from commonData ", ManifestationInfo.getSeries( commonData, localData ), expected );
 
 
-    var commonDataString =
+    commonDataString =
         '<ting:container' +
         ' xmlns:ting="http://www.dbc.dk/ting"' +
         ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
@@ -733,13 +733,13 @@ UnitTest.addFixture( "ManifestationInfo.getSeries", function() {
         '<dc:description xsi:type="dkdcplus:series">2. del af: Harry Potter og De Vises Sten ; woot-woot</dc:description>' +
         '</dkabm:record>' +
         '</ting:container>';
-    var localDataString = '<empty/>';
+    localDataString = '<empty/>';
 
 
-    var commonData = XmlUtil.fromString( commonDataString );
-    var localData = XmlUtil.fromString( localDataString );
+    commonData = XmlUtil.fromString( commonDataString );
+    localData = XmlUtil.fromString( localDataString );
 
-    var expected = {
+    expected = {
         "title": "2. del af: Harry Potter og De Vises Sten ; woot-woot",
         "instalment": null
     };
@@ -747,7 +747,7 @@ UnitTest.addFixture( "ManifestationInfo.getSeries", function() {
     Assert.equalValue( "get series description from commonData not split by ';' ", ManifestationInfo.getSeries( commonData, localData ), expected );
 
 
-    var commonDataString =
+    commonDataString =
         '<ting:container' +
         ' xmlns:ting="http://www.dbc.dk/ting"' +
         ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
@@ -768,7 +768,8 @@ UnitTest.addFixture( "ManifestationInfo.getSeries", function() {
         '<dc:creator xsi:type="oss:sort">Bøgh Andersen, Kenneth</dc:creator>' +
         '</dkabm:record>' +
         '</ting:container>';
-    var localDataString = 
+
+    localDataString =
         '<ting:localData' +
         ' xmlns:ting="http://www.dbc.dk/ting"' +
         ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
@@ -790,10 +791,10 @@ UnitTest.addFixture( "ManifestationInfo.getSeries", function() {
         '</dkabm:record>' +
         '</ting:localData>';
 
-    var commonData = XmlUtil.fromString( commonDataString );
-    var localData = XmlUtil.fromString( localDataString );
+    commonData = XmlUtil.fromString( commonDataString );
+    localData = XmlUtil.fromString( localDataString );
 
-    var expected = {
+    expected = {
         "title": "THIS Den store djævlekrig",
         "instalment": "1"
     };
@@ -801,19 +802,19 @@ UnitTest.addFixture( "ManifestationInfo.getSeries", function() {
     Assert.equalValue( "get series title from localData when both local and commonData is present ", ManifestationInfo.getSeries( commonData, localData ), expected );
 
 
-    var commonDataString = '<empty/>';
-    var localDataString =  '<empty/>';
+    commonDataString = '<empty/>';
+    localDataString = '<empty/>';
 
-    var commonData = XmlUtil.fromString( commonDataString );
-    var localData = XmlUtil.fromString( localDataString );
+    commonData = XmlUtil.fromString( commonDataString );
+    localData = XmlUtil.fromString( localDataString );
 
-    var expected = null;
+    expected = null;
 
     Assert.equal( "get series title from common or local - none found ", ManifestationInfo.getSeries( commonData, localData ), expected );
 
 
-    var commonDataString = '<empty/>';
-    var localDataString = 
+    commonDataString = '<empty/>';
+    localDataString =
         '<ting:localData' +
         ' xmlns:ting="http://www.dbc.dk/ting"' +
         ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
@@ -835,10 +836,10 @@ UnitTest.addFixture( "ManifestationInfo.getSeries", function() {
         '</dkabm:record>' +
         '</ting:localData>';
 
-    var commonData = XmlUtil.fromString( commonDataString );
-    var localData = XmlUtil.fromString( localDataString );
+    commonData = XmlUtil.fromString( commonDataString );
+    localData = XmlUtil.fromString( localDataString );
 
-    var expected = {
+    expected = {
         "title": "Den store djævlekrig",
         "instalment": null
     };
@@ -852,182 +853,182 @@ UnitTest.addFixture( "ManifestationInfo.getCreators", function() {
 
     var commonDataString = '<empty/>';
     var localDataString =
-            '<ting:localData' +
-            ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
-            ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-            ' xmlns:dcterms="http://purl.org/dc/terms/"' +
-            ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
-            ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
-            ' xmlns:docbook="http://docbook.org/ns/docbook"' +
-            ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
-            ' xmlns:ting="http://www.dbc.dk/ting"' +
-            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dkabm:record>' +
-            '<ac:identifier>54969562|700400</ac:identifier>' +
-            '<ac:source>Bibliotekskatalog</ac:source>' +
-            '<dc:title>Vildheks</dc:title>' +
-            '<dc:title xsi:type="dkdcplus:full">Vildheks</dc:title>' +
-            '<dcterms:alternative>Vildheks</dcterms:alternative>' +
-            '<dc:creator xsi:type="dkdcplus:aus">Kaspar Munk</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Munk, Kaspar</dc:creator>' +
-            '<dc:creator xsi:type="dkdcplus:drt">Kaspar Munk</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Munk, Kaspar</dc:creator>' +
-            '<dc:creator xsi:type="dkdcplus:cng">Adam Wallensten</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Wallensten, Adam</dc:creator>' +
-            '<dc:creator xsi:type="dkdcplus:aus">Poul Berg</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Berg, Poul (f. 1970-08-19)</dc:creator>' +
-            '<dc:creator xsi:type="dkdcplus:aus">Bo hr. Hansen</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Hansen, Bo hr. (f. 1961)</dc:creator>' +
-            '</dkabm:record>' +
-            '</ting:localData>';
+        '<ting:localData' +
+        ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:dcterms="http://purl.org/dc/terms/"' +
+        ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
+        ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
+        ' xmlns:docbook="http://docbook.org/ns/docbook"' +
+        ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
+        ' xmlns:ting="http://www.dbc.dk/ting"' +
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+        '<dkabm:record>' +
+        '<ac:identifier>54969562|700400</ac:identifier>' +
+        '<ac:source>Bibliotekskatalog</ac:source>' +
+        '<dc:title>Vildheks</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Vildheks</dc:title>' +
+        '<dcterms:alternative>Vildheks</dcterms:alternative>' +
+        '<dc:creator xsi:type="dkdcplus:aus">Kaspar Munk</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Munk, Kaspar</dc:creator>' +
+        '<dc:creator xsi:type="dkdcplus:drt">Kaspar Munk</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Munk, Kaspar</dc:creator>' +
+        '<dc:creator xsi:type="dkdcplus:cng">Adam Wallensten</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Wallensten, Adam</dc:creator>' +
+        '<dc:creator xsi:type="dkdcplus:aus">Poul Berg</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Berg, Poul (f. 1970-08-19)</dc:creator>' +
+        '<dc:creator xsi:type="dkdcplus:aus">Bo hr. Hansen</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Hansen, Bo hr. (f. 1961)</dc:creator>' +
+        '</dkabm:record>' +
+        '</ting:localData>';
 
     var localData = XmlUtil.fromString( localDataString );
     var commonData = XmlUtil.fromString( commonDataString );
 
     var expected = [
-        { type : "aus", value : "Kaspar Munk" },
-        { type : "drt", value : "Kaspar Munk" },
-        { type : "cng", value : "Adam Wallensten" },
-        { type : "aus", value : "Poul Berg" },
-        { type : "aus", value : "Bo hr. Hansen" }
+        { type: "aus", value: "Kaspar Munk" },
+        { type: "drt", value: "Kaspar Munk" },
+        { type: "cng", value: "Adam Wallensten" },
+        { type: "aus", value: "Poul Berg" },
+        { type: "aus", value: "Bo hr. Hansen" }
     ];
 
     Assert.equalValue( "get creators from localData ", ManifestationInfo.getCreators( commonData, localData ), expected );
 
     commonDataString =
-            '<ting:container' +
-            ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
-            ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-            ' xmlns:dcterms="http://purl.org/dc/terms/"' +
-            ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
-            ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
-            ' xmlns:docbook="http://docbook.org/ns/docbook"' +
-            ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
-            ' xmlns:ting="http://www.dbc.dk/ting"' +
-            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dkabm:record>' +
-            '<ac:identifier>54969562|700400</ac:identifier>' +
-            '<ac:source>Bibliotekskatalog</ac:source>' +
-            '<dc:title>Vildheks</dc:title>' +
-            '<dc:title xsi:type="dkdcplus:full">Vildheks</dc:title>' +
-            '<dcterms:alternative>Vildheks</dcterms:alternative>' +
-            '<dc:creator xsi:type="dkdcplus:aus">Kaspar Munk</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Munk, Kaspar</dc:creator>' +
-            '<dc:creator xsi:type="dkdcplus:drt">Kaspar Munk</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Munk, Kaspar</dc:creator>' +
-            '<dc:creator xsi:type="dkdcplus:cng">Adam Wallensten</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Wallensten, Adam</dc:creator>' +
-            '<dc:creator xsi:type="dkdcplus:aus">Poul Berg</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Berg, Poul (f. 1970-08-19)</dc:creator>' +
-            '<dc:creator xsi:type="dkdcplus:aus">Bo hr. Hansen</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Hansen, Bo hr. (f. 1961)</dc:creator>' +
-            '</dkabm:record>' +
-            '</ting:container>';
+        '<ting:container' +
+        ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:dcterms="http://purl.org/dc/terms/"' +
+        ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
+        ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
+        ' xmlns:docbook="http://docbook.org/ns/docbook"' +
+        ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
+        ' xmlns:ting="http://www.dbc.dk/ting"' +
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+        '<dkabm:record>' +
+        '<ac:identifier>54969562|700400</ac:identifier>' +
+        '<ac:source>Bibliotekskatalog</ac:source>' +
+        '<dc:title>Vildheks</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Vildheks</dc:title>' +
+        '<dcterms:alternative>Vildheks</dcterms:alternative>' +
+        '<dc:creator xsi:type="dkdcplus:aus">Kaspar Munk</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Munk, Kaspar</dc:creator>' +
+        '<dc:creator xsi:type="dkdcplus:drt">Kaspar Munk</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Munk, Kaspar</dc:creator>' +
+        '<dc:creator xsi:type="dkdcplus:cng">Adam Wallensten</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Wallensten, Adam</dc:creator>' +
+        '<dc:creator xsi:type="dkdcplus:aus">Poul Berg</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Berg, Poul (f. 1970-08-19)</dc:creator>' +
+        '<dc:creator xsi:type="dkdcplus:aus">Bo hr. Hansen</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Hansen, Bo hr. (f. 1961)</dc:creator>' +
+        '</dkabm:record>' +
+        '</ting:container>';
     localDataString = '<empty/>';
 
     localData = XmlUtil.fromString( localDataString );
     commonData = XmlUtil.fromString( commonDataString );
 
     expected = [
-        { type : "aus", value : "Kaspar Munk" },
-        { type : "drt", value : "Kaspar Munk" },
-        { type : "cng", value : "Adam Wallensten" },
-        { type : "aus", value : "Poul Berg" },
-        { type : "aus", value : "Bo hr. Hansen" }
+        { type: "aus", value: "Kaspar Munk" },
+        { type: "drt", value: "Kaspar Munk" },
+        { type: "cng", value: "Adam Wallensten" },
+        { type: "aus", value: "Poul Berg" },
+        { type: "aus", value: "Bo hr. Hansen" }
     ];
 
     Assert.equalValue( "get creators from commonData ", ManifestationInfo.getCreators( commonData, localData ), expected );
 
     commonDataString =
-            '<ting:container' +
-            ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
-            ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-            ' xmlns:dcterms="http://purl.org/dc/terms/"' +
-            ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
-            ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
-            ' xmlns:docbook="http://docbook.org/ns/docbook"' +
-            ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
-            ' xmlns:ting="http://www.dbc.dk/ting"' +
-            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dkabm:record>' +
-            '<ac:identifier>54969562|700400</ac:identifier>' +
-            '<ac:source>Bibliotekskatalog</ac:source>' +
-            '<dc:title>Vildheks</dc:title>' +
-            '<dc:title xsi:type="dkdcplus:full">Vildheks</dc:title>' +
-            '<dcterms:alternative>Vildheks</dcterms:alternative>' +
-            '<dc:creator xsi:type="dkdcplus:cng">Adam Wallensten</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Wallensten, Adam</dc:creator>' +
-            '<dc:creator xsi:type="dkdcplus:aus">Poul Berg</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Berg, Poul (f. 1970-08-19)</dc:creator>' +
-            '<dc:creator xsi:type="dkdcplus:aus">Bo hr. Hansen</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Hansen, Bo hr. (f. 1961)</dc:creator>' +
-            '</dkabm:record>' +
-            '</ting:container>';
+        '<ting:container' +
+        ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:dcterms="http://purl.org/dc/terms/"' +
+        ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
+        ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
+        ' xmlns:docbook="http://docbook.org/ns/docbook"' +
+        ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
+        ' xmlns:ting="http://www.dbc.dk/ting"' +
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+        '<dkabm:record>' +
+        '<ac:identifier>54969562|700400</ac:identifier>' +
+        '<ac:source>Bibliotekskatalog</ac:source>' +
+        '<dc:title>Vildheks</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Vildheks</dc:title>' +
+        '<dcterms:alternative>Vildheks</dcterms:alternative>' +
+        '<dc:creator xsi:type="dkdcplus:cng">Adam Wallensten</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Wallensten, Adam</dc:creator>' +
+        '<dc:creator xsi:type="dkdcplus:aus">Poul Berg</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Berg, Poul (f. 1970-08-19)</dc:creator>' +
+        '<dc:creator xsi:type="dkdcplus:aus">Bo hr. Hansen</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Hansen, Bo hr. (f. 1961)</dc:creator>' +
+        '</dkabm:record>' +
+        '</ting:container>';
     localDataString =
-            '<ting:localData' +
-            ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
-            ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-            ' xmlns:dcterms="http://purl.org/dc/terms/"' +
-            ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
-            ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
-            ' xmlns:docbook="http://docbook.org/ns/docbook"' +
-            ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
-            ' xmlns:ting="http://www.dbc.dk/ting"' +
-            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dkabm:record>' +
-            '<ac:identifier>54969562|700400</ac:identifier>' +
-            '<ac:source>Bibliotekskatalog</ac:source>' +
-            '<dc:title>Vildheks</dc:title>' +
-            '<dc:title xsi:type="dkdcplus:full">Vildheks</dc:title>' +
-            '<dcterms:alternative>Vildheks</dcterms:alternative>' +
-            '<dc:creator xsi:type="dkdcplus:aus">Kaspar Munk</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Munk, Kaspar</dc:creator>' +
-            '<dc:creator xsi:type="dkdcplus:drt">Kaspar Munk</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Munk, Kaspar</dc:creator>' +
-            '</dkabm:record>' +
-            '</ting:localData>';
+        '<ting:localData' +
+        ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:dcterms="http://purl.org/dc/terms/"' +
+        ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
+        ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
+        ' xmlns:docbook="http://docbook.org/ns/docbook"' +
+        ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
+        ' xmlns:ting="http://www.dbc.dk/ting"' +
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+        '<dkabm:record>' +
+        '<ac:identifier>54969562|700400</ac:identifier>' +
+        '<ac:source>Bibliotekskatalog</ac:source>' +
+        '<dc:title>Vildheks</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Vildheks</dc:title>' +
+        '<dcterms:alternative>Vildheks</dcterms:alternative>' +
+        '<dc:creator xsi:type="dkdcplus:aus">Kaspar Munk</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Munk, Kaspar</dc:creator>' +
+        '<dc:creator xsi:type="dkdcplus:drt">Kaspar Munk</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Munk, Kaspar</dc:creator>' +
+        '</dkabm:record>' +
+        '</ting:localData>';
 
     localData = XmlUtil.fromString( localDataString );
     commonData = XmlUtil.fromString( commonDataString );
 
     expected = [
-        { type : "aus", value : "Kaspar Munk" },
-        { type : "drt", value : "Kaspar Munk" }
+        { type: "aus", value: "Kaspar Munk" },
+        { type: "drt", value: "Kaspar Munk" }
     ];
 
     Assert.equalValue( "get creators from localData over commonData ", ManifestationInfo.getCreators( commonData, localData ), expected );
 
-    var commonDataString = '<empty/>';
-    var localDataString =
-            '<ting:localData' +
-            ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
-            ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-            ' xmlns:dcterms="http://purl.org/dc/terms/"' +
-            ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
-            ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
-            ' xmlns:docbook="http://docbook.org/ns/docbook"' +
-            ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
-            ' xmlns:ting="http://www.dbc.dk/ting"' +
-            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dkabm:record>' +
-            '<ac:identifier>54969562|700400</ac:identifier>' +
-            '<ac:source>Bibliotekskatalog</ac:source>' +
-            '<dc:title>Vildheks</dc:title>' +
-            '<dc:title xsi:type="dkdcplus:full">Vildheks</dc:title>' +
-            '<dcterms:alternative>Vildheks</dcterms:alternative>' +
-            '<dc:creator xsi:type="">Kaspar Munk</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Munk, Kaspar</dc:creator>' +
-            '<dc:creator>Kaspar Munk</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Munk, Kaspar</dc:creator>' +
-            '</dkabm:record>' +
-            '</ting:localData>';
+    commonDataString = '<empty/>';
+    localDataString =
+        '<ting:localData' +
+        ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:dcterms="http://purl.org/dc/terms/"' +
+        ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
+        ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
+        ' xmlns:docbook="http://docbook.org/ns/docbook"' +
+        ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
+        ' xmlns:ting="http://www.dbc.dk/ting"' +
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+        '<dkabm:record>' +
+        '<ac:identifier>54969562|700400</ac:identifier>' +
+        '<ac:source>Bibliotekskatalog</ac:source>' +
+        '<dc:title>Vildheks</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Vildheks</dc:title>' +
+        '<dcterms:alternative>Vildheks</dcterms:alternative>' +
+        '<dc:creator xsi:type="">Kaspar Munk</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Munk, Kaspar</dc:creator>' +
+        '<dc:creator>Kaspar Munk</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Munk, Kaspar</dc:creator>' +
+        '</dkabm:record>' +
+        '</ting:localData>';
 
-    var localData = XmlUtil.fromString( localDataString );
-    var commonData = XmlUtil.fromString( commonDataString );
+    localData = XmlUtil.fromString( localDataString );
+    commonData = XmlUtil.fromString( commonDataString );
 
-    var expected = [
-        { type : null, value : "Kaspar Munk" },
-        { type : null, value : "Kaspar Munk" }
+    expected = [
+        { type: null, value: "Kaspar Munk" },
+        { type: null, value: "Kaspar Munk" }
     ];
 
     Assert.equalValue( "get creators with no type ", ManifestationInfo.getCreators( commonData, localData ), expected );
@@ -1058,7 +1059,7 @@ UnitTest.addFixture( "ManifestationInfo.getTypes", function() {
 
     Assert.equalValue( "get one type from dc stream ", ManifestationInfo.getTypes( dcStream ), expected );
 
-    var dcStreamString =
+    dcStreamString =
         '<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
         '<dc:title>værkstedstekniske beregninger</dc:title>' +
         '<dc:language>Dansk</dc:language>' +
@@ -1073,9 +1074,9 @@ UnitTest.addFixture( "ManifestationInfo.getTypes", function() {
         '<dc:relation>50378705</dc:relation>' +
         '</oai_dc:dc>';
 
-    var dcStream = XmlUtil.fromString( dcStreamString );
+    dcStream = XmlUtil.fromString( dcStreamString );
 
-    var expected = [ "Bog" ];
+    expected = [ "Bog" ];
 
     Assert.equalValue( "get one type from dc stream with whitespace ", ManifestationInfo.getTypes( dcStream ), expected );
 
@@ -1173,7 +1174,7 @@ UnitTest.addFixture( "ManifestationInfo.getTypes", function() {
 
     dcStream = XmlUtil.fromString( dcStreamString );
 
-    expected = [ ];
+    expected = [];
 
     Assert.equalValue( "accept no types ", ManifestationInfo.getTypes( dcStream ), expected );
 
@@ -1307,7 +1308,7 @@ UnitTest.addFixture( "ManifestationInfo.getAbstract", function() {
         '<dc:subject xsi:type="dkdcplus:DBCF">mor-datter forholdet</dc:subject>' +
         '<dc:subject xsi:type="dkdcplus:DBCF">socialt udsatte</dc:subject>' +
         '<dc:subject xsi:type="dkdcplus:DBCF">underklassen</dc:subject>' +
-//        '<dcterms:abstract>I en række mails fortæller Karina Pedersen (f. 1976) historien om sin opvækst i Korskærparken i Fredericia. Med sin egen underklasse-familie som eksempel, tager hun et opgør med velfærdsdanmark og de sociale ydelser</dcterms:abstract>' +
+        //        '<dcterms:abstract>I en række mails fortæller Karina Pedersen (f. 1976) historien om sin opvækst i Korskærparken i Fredericia. Med sin egen underklasse-familie som eksempel, tager hun et opgør med velfærdsdanmark og de sociale ydelser</dcterms:abstract>' +
         '<dcterms:audience>alment niveau</dcterms:audience>' +
         '<dcterms:audience>voksenmaterialer</dcterms:audience>' +
         '<dkdcplus:version>1. udgave, 1. oplag (2016)</dkdcplus:version>' +
@@ -1412,7 +1413,7 @@ UnitTest.addFixture( "ManifestationInfo.getAbstract", function() {
         '<dc:subject xsi:type="dkdcplus:DBCF">mor-datter forholdet</dc:subject>' +
         '<dc:subject xsi:type="dkdcplus:DBCF">socialt udsatte</dc:subject>' +
         '<dc:subject xsi:type="dkdcplus:DBCF">underklassen</dc:subject>' +
-//        '<dcterms:abstract>I en række mails fortæller Karina Pedersen (f. 1976) historien om sin opvækst i Korskærparken i Fredericia. Med sin egen underklasse-familie som eksempel, tager hun et opgør med velfærdsdanmark og de sociale ydelser</dcterms:abstract>' +
+        //        '<dcterms:abstract>I en række mails fortæller Karina Pedersen (f. 1976) historien om sin opvækst i Korskærparken i Fredericia. Med sin egen underklasse-familie som eksempel, tager hun et opgør med velfærdsdanmark og de sociale ydelser</dcterms:abstract>' +
         '<dcterms:audience>alment niveau</dcterms:audience>' +
         '<dcterms:audience>voksenmaterialer</dcterms:audience>' +
         '<dkdcplus:version>1. udgave, 1. oplag (2016)</dkdcplus:version>' +
@@ -1527,201 +1528,201 @@ UnitTest.addFixture( "ManifestationInfo.getAbstract", function() {
 UnitTest.addFixture( "ManifestationInfo.getSubjects", function() {
 
     var localDataString = '<ting:localData' +
-            ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
-            ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-            ' xmlns:dcterms="http://purl.org/dc/terms/"' +
-            ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
-            ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
-            ' xmlns:docbook="http://docbook.org/ns/docbook"' +
-            ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
-            ' xmlns:ting="http://www.dbc.dk/ting"' +
-            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dkabm:record>' +
-            '<dc:title>Djævelens lærling</dc:title>' +
-            '<dc:title xsi:type="dkdcplus:full">Djævelens lærling</dc:title>' +
-            '<dc:creator xsi:type="dkdcplus:aut">Kenneth Bøgh Andersen</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Bøgh Andersen, Kenneth</dc:creator>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">Helvede</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DK5-Text">Skønlitteratur</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">fantasy</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:genre">fantasy</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 12 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 13 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 14 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DK5">sk</dc:subject>' +
-            '</dkabm:record>' +
-            '</ting:localData>';
+        ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:dcterms="http://purl.org/dc/terms/"' +
+        ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
+        ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
+        ' xmlns:docbook="http://docbook.org/ns/docbook"' +
+        ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
+        ' xmlns:ting="http://www.dbc.dk/ting"' +
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+        '<dkabm:record>' +
+        '<dc:title>Djævelens lærling</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Djævelens lærling</dc:title>' +
+        '<dc:creator xsi:type="dkdcplus:aut">Kenneth Bøgh Andersen</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Bøgh Andersen, Kenneth</dc:creator>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">Helvede</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DK5-Text">Skønlitteratur</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">fantasy</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:genre">fantasy</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 12 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 13 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 14 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DK5">sk</dc:subject>' +
+        '</dkabm:record>' +
+        '</ting:localData>';
     var commonDataString = '<empty/>';
 
     var localData = XmlUtil.fromString( localDataString );
     var commonData = XmlUtil.fromString( commonDataString );
 
     var expected = [
-        { type : "DBCS", value : "Helvede" },
-        { type : "DK5-Text", value : "Skønlitteratur" },
-        { type : "DBCS", value : "fantasy" },
-        { type : "genre", value : "fantasy" },
-        { type : "DBCN", value : "for 12 år" },
-        { type : "DBCN", value : "for 13 år" },
-        { type : "DBCN", value : "for 14 år" },
-        { type : "DK5", value : "sk" }
+        { type: "DBCS", value: "Helvede" },
+        { type: "DK5-Text", value: "Skønlitteratur" },
+        { type: "DBCS", value: "fantasy" },
+        { type: "genre", value: "fantasy" },
+        { type: "DBCN", value: "for 12 år" },
+        { type: "DBCN", value: "for 13 år" },
+        { type: "DBCN", value: "for 14 år" },
+        { type: "DK5", value: "sk" }
     ];
 
     Assert.equalValue( "get subjects from local stream ", ManifestationInfo.getSubjects( commonData, localData ), expected );
 
     localDataString = '<ting:localData' +
-            ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
-            ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-            ' xmlns:dcterms="http://purl.org/dc/terms/"' +
-            ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
-            ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
-            ' xmlns:docbook="http://docbook.org/ns/docbook"' +
-            ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
-            ' xmlns:ting="http://www.dbc.dk/ting"' +
-            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dkabm:record>' +
-            '<dc:title>Djævelens lærling</dc:title>' +
-            '<dc:title xsi:type="dkdcplus:full">Djævelens lærling</dc:title>' +
-            '<dc:creator xsi:type="dkdcplus:aut">Kenneth Bøgh Andersen</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Bøgh Andersen, Kenneth</dc:creator>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">Helvede</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DK5-Text">Skønlitteratur</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">fantasy</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:genre">fantasy</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DK5">sk</dc:subject>' +
-            '</dkabm:record>' +
-            '</ting:localData>';
+        ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:dcterms="http://purl.org/dc/terms/"' +
+        ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
+        ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
+        ' xmlns:docbook="http://docbook.org/ns/docbook"' +
+        ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
+        ' xmlns:ting="http://www.dbc.dk/ting"' +
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+        '<dkabm:record>' +
+        '<dc:title>Djævelens lærling</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Djævelens lærling</dc:title>' +
+        '<dc:creator xsi:type="dkdcplus:aut">Kenneth Bøgh Andersen</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Bøgh Andersen, Kenneth</dc:creator>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">Helvede</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DK5-Text">Skønlitteratur</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">fantasy</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:genre">fantasy</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DK5">sk</dc:subject>' +
+        '</dkabm:record>' +
+        '</ting:localData>';
     commonDataString = '<ting:container' +
-            ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
-            ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-            ' xmlns:dcterms="http://purl.org/dc/terms/"' +
-            ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
-            ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
-            ' xmlns:docbook="http://docbook.org/ns/docbook"' +
-            ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
-            ' xmlns:ting="http://www.dbc.dk/ting"' +
-            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dkabm:record>' +
-            '<dc:title>Djævelens lærling</dc:title>' +
-            '<dc:title xsi:type="dkdcplus:full">Djævelens lærling</dc:title>' +
-            '<dc:creator xsi:type="dkdcplus:aut">Kenneth Bøgh Andersen</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Bøgh Andersen, Kenneth</dc:creator>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 12 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 13 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 14 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DK5">sk</dc:subject>' +
-            '</dkabm:record>' +
-            '</ting:container>';
+        ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:dcterms="http://purl.org/dc/terms/"' +
+        ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
+        ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
+        ' xmlns:docbook="http://docbook.org/ns/docbook"' +
+        ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
+        ' xmlns:ting="http://www.dbc.dk/ting"' +
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+        '<dkabm:record>' +
+        '<dc:title>Djævelens lærling</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Djævelens lærling</dc:title>' +
+        '<dc:creator xsi:type="dkdcplus:aut">Kenneth Bøgh Andersen</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Bøgh Andersen, Kenneth</dc:creator>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 12 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 13 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 14 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DK5">sk</dc:subject>' +
+        '</dkabm:record>' +
+        '</ting:container>';
 
     localData = XmlUtil.fromString( localDataString );
     commonData = XmlUtil.fromString( commonDataString );
 
     expected = [
-        { type : "DBCS", value : "Helvede" },
-        { type : "DK5-Text", value : "Skønlitteratur" },
-        { type : "DBCS", value : "fantasy" },
-        { type : "genre", value : "fantasy" },
-        { type : "DK5", value : "sk" }
+        { type: "DBCS", value: "Helvede" },
+        { type: "DK5-Text", value: "Skønlitteratur" },
+        { type: "DBCS", value: "fantasy" },
+        { type: "genre", value: "fantasy" },
+        { type: "DK5", value: "sk" }
     ];
 
     Assert.equalValue( "get subjects from local stream over common stream ", ManifestationInfo.getSubjects( commonData, localData ), expected );
 
     localDataString = '<empty/>';
     commonDataString = '<ting:container' +
-            ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
-            ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-            ' xmlns:dcterms="http://purl.org/dc/terms/"' +
-            ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
-            ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
-            ' xmlns:docbook="http://docbook.org/ns/docbook"' +
-            ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
-            ' xmlns:ting="http://www.dbc.dk/ting"' +
-            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dkabm:record>' +
-            '<dc:title>Djævelens lærling</dc:title>' +
-            '<dc:title xsi:type="dkdcplus:full">Djævelens lærling</dc:title>' +
-            '<dc:creator xsi:type="dkdcplus:aut">Kenneth Bøgh Andersen</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Bøgh Andersen, Kenneth</dc:creator>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">Helvede</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DK5-Text">Skønlitteratur</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">fantasy</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:genre">fantasy</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 12 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 13 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 14 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DK5">sk</dc:subject>' +
-            '</dkabm:record>' +
-            '</ting:container>';
+        ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:dcterms="http://purl.org/dc/terms/"' +
+        ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
+        ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
+        ' xmlns:docbook="http://docbook.org/ns/docbook"' +
+        ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
+        ' xmlns:ting="http://www.dbc.dk/ting"' +
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+        '<dkabm:record>' +
+        '<dc:title>Djævelens lærling</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Djævelens lærling</dc:title>' +
+        '<dc:creator xsi:type="dkdcplus:aut">Kenneth Bøgh Andersen</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Bøgh Andersen, Kenneth</dc:creator>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">Helvede</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DK5-Text">Skønlitteratur</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">fantasy</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:genre">fantasy</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 12 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 13 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 14 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DK5">sk</dc:subject>' +
+        '</dkabm:record>' +
+        '</ting:container>';
 
     localData = XmlUtil.fromString( localDataString );
     commonData = XmlUtil.fromString( commonDataString );
 
     expected = [
-        { type : "DBCS", value : "Helvede" },
-        { type : "DK5-Text", value : "Skønlitteratur" },
-        { type : "DBCS", value : "fantasy" },
-        { type : "genre", value : "fantasy" },
-        { type : "DBCN", value : "for 12 år" },
-        { type : "DBCN", value : "for 13 år" },
-        { type : "DBCN", value : "for 14 år" },
-        { type : "DK5", value : "sk" }
+        { type: "DBCS", value: "Helvede" },
+        { type: "DK5-Text", value: "Skønlitteratur" },
+        { type: "DBCS", value: "fantasy" },
+        { type: "genre", value: "fantasy" },
+        { type: "DBCN", value: "for 12 år" },
+        { type: "DBCN", value: "for 13 år" },
+        { type: "DBCN", value: "for 14 år" },
+        { type: "DK5", value: "sk" }
     ];
 
     Assert.equalValue( "get subjects from common stream ", ManifestationInfo.getSubjects( commonData, localData ), expected );
 
     localDataString = '<ting:localData' +
-            ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
-            ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-            ' xmlns:dcterms="http://purl.org/dc/terms/"' +
-            ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
-            ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
-            ' xmlns:docbook="http://docbook.org/ns/docbook"' +
-            ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
-            ' xmlns:ting="http://www.dbc.dk/ting"' +
-            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dkabm:record>' +
-            '<dc:title>Djævelens lærling</dc:title>' +
-            '<dc:title xsi:type="dkdcplus:full">Djævelens lærling</dc:title>' +
-            '<dc:creator xsi:type="dkdcplus:aut">Kenneth Bøgh Andersen</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Bøgh Andersen, Kenneth</dc:creator>' +
-            '</dkabm:record>' +
-            '</ting:localData>';
+        ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:dcterms="http://purl.org/dc/terms/"' +
+        ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
+        ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
+        ' xmlns:docbook="http://docbook.org/ns/docbook"' +
+        ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
+        ' xmlns:ting="http://www.dbc.dk/ting"' +
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+        '<dkabm:record>' +
+        '<dc:title>Djævelens lærling</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Djævelens lærling</dc:title>' +
+        '<dc:creator xsi:type="dkdcplus:aut">Kenneth Bøgh Andersen</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Bøgh Andersen, Kenneth</dc:creator>' +
+        '</dkabm:record>' +
+        '</ting:localData>';
     commonDataString = '<empty/>';
 
     localData = XmlUtil.fromString( localDataString );
     commonData = XmlUtil.fromString( commonDataString );
 
-    expected = [ ];
+    expected = [];
 
     Assert.equalValue( "get subjects from  stream with no subjects", ManifestationInfo.getSubjects( commonData, localData ), expected );
 
     localDataString = '<ting:localData' +
-            ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
-            ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-            ' xmlns:dcterms="http://purl.org/dc/terms/"' +
-            ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
-            ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
-            ' xmlns:docbook="http://docbook.org/ns/docbook"' +
-            ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
-            ' xmlns:ting="http://www.dbc.dk/ting"' +
-            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dkabm:record>' +
-            '<dc:title>Djævelens lærling</dc:title>' +
-            '<dc:title xsi:type="dkdcplus:full">Djævelens lærling</dc:title>' +
-            '<dc:creator xsi:type="dkdcplus:aut">Kenneth Bøgh Andersen</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Bøgh Andersen, Kenneth</dc:creator>' +
-            '<dc:subject xsi:type="">Helvede</dc:subject>' +
-            '<dc:subject>Skønlitteratur</dc:subject>' +
-            '</dkabm:record>' +
-            '</ting:localData>';
+        ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:dcterms="http://purl.org/dc/terms/"' +
+        ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
+        ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
+        ' xmlns:docbook="http://docbook.org/ns/docbook"' +
+        ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
+        ' xmlns:ting="http://www.dbc.dk/ting"' +
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+        '<dkabm:record>' +
+        '<dc:title>Djævelens lærling</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Djævelens lærling</dc:title>' +
+        '<dc:creator xsi:type="dkdcplus:aut">Kenneth Bøgh Andersen</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Bøgh Andersen, Kenneth</dc:creator>' +
+        '<dc:subject xsi:type="">Helvede</dc:subject>' +
+        '<dc:subject>Skønlitteratur</dc:subject>' +
+        '</dkabm:record>' +
+        '</ting:localData>';
     commonDataString = '<empty/>';
 
     localData = XmlUtil.fromString( localDataString );
     commonData = XmlUtil.fromString( commonDataString );
 
     expected = [
-        { "type" : null, "value" : "Helvede" },
-        { "type" : null, "value" : "Skønlitteratur" }
+        { "type": null, "value": "Helvede" },
+        { "type": null, "value": "Skønlitteratur" }
     ];
 
     Assert.equalValue( "get subjects from ting stream with no types", ManifestationInfo.getSubjects( commonData, localData ), expected );
@@ -1732,51 +1733,51 @@ UnitTest.addFixture( "ManifestationInfo.getSubjects", function() {
 UnitTest.addFixture( "ManifestationInfo.getPriorityKeys", function() {
 
     var localDataString = '<ting:localData' +
-            ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
-            ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-            ' xmlns:dcterms="http://purl.org/dc/terms/"' +
-            ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
-            ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
-            ' xmlns:docbook="http://docbook.org/ns/docbook"' +
-            ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
-            ' xmlns:ting="http://www.dbc.dk/ting"' +
-            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dkabm:record>' +
-            '<ac:identifier>21496782|870970</ac:identifier>' +
-            '<ac:source>Bibliotekskatalog</ac:source>' +
-            '<dc:title>Det gyldne kompas</dc:title>' +
-            '<dc:title xsi:type="dkdcplus:full">Det gyldne kompas</dc:title>' +
-            '<dc:creator xsi:type="dkdcplus:aut">Philip Pullman</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Pullman, Philip</dc:creator>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">Arktis</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">England</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">Norge</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DK5-Text">Skønlitteratur</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">det gode</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">det onde</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCO">fantasy</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:genre">fantasy</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 12 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 13 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 14 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">parallelle verdener</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DK5">sk</dc:subject>' +
-            '<dcterms:abstract>Fantasy. Lyra - 11 år og forældreløs - kommer på sporet af noget mystisk og uhyggeligt, da flere og flere børn forsvinder. Løsningen findes måske højt mod nord, mellem panserbjørne og flyvende hekse</dcterms:abstract>' +
-            '<dc:description xsi:type="dkdcplus:series">Samhørende: Det gyldne kompas ; Skyggernes kniv ; Ravkikkerten</dc:description>' +
-            '<dcterms:audience xsi:type="dkdcplus:age">fra 12 år</dcterms:audience>' +
-            '<dcterms:audience>børnematerialer</dcterms:audience>' +
-            '<dkdcplus:version>2. oplag (2001)</dkdcplus:version>' +
-            '<dc:publisher>Gyldendal</dc:publisher>' +
-            '<dc:date>1996</dc:date>' +
-            '<dc:type xsi:type="dkdcplus:BibDK-Type">Bog</dc:type>' +
-            '<dc:format>illustreret</dc:format>' +
-            '<dcterms:extent>400 sider</dcterms:extent>' +
-            '<dc:identifier xsi:type="dkdcplus:ISBN">87-00-26818-6</dc:identifier>' +
-            '<dc:source>The Golden compass</dc:source>' +
-            '<dc:language xsi:type="dcterms:ISO639-2">dan</dc:language>' +
-            '<dc:language>Dansk</dc:language>' +
-            '</dkabm:record>' +
-            '</ting:localData>';
+        ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:dcterms="http://purl.org/dc/terms/"' +
+        ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
+        ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
+        ' xmlns:docbook="http://docbook.org/ns/docbook"' +
+        ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
+        ' xmlns:ting="http://www.dbc.dk/ting"' +
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+        '<dkabm:record>' +
+        '<ac:identifier>21496782|870970</ac:identifier>' +
+        '<ac:source>Bibliotekskatalog</ac:source>' +
+        '<dc:title>Det gyldne kompas</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Det gyldne kompas</dc:title>' +
+        '<dc:creator xsi:type="dkdcplus:aut">Philip Pullman</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Pullman, Philip</dc:creator>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">Arktis</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">England</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">Norge</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DK5-Text">Skønlitteratur</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">det gode</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">det onde</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCO">fantasy</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:genre">fantasy</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 12 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 13 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 14 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">parallelle verdener</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DK5">sk</dc:subject>' +
+        '<dcterms:abstract>Fantasy. Lyra - 11 år og forældreløs - kommer på sporet af noget mystisk og uhyggeligt, da flere og flere børn forsvinder. Løsningen findes måske højt mod nord, mellem panserbjørne og flyvende hekse</dcterms:abstract>' +
+        '<dc:description xsi:type="dkdcplus:series">Samhørende: Det gyldne kompas ; Skyggernes kniv ; Ravkikkerten</dc:description>' +
+        '<dcterms:audience xsi:type="dkdcplus:age">fra 12 år</dcterms:audience>' +
+        '<dcterms:audience>børnematerialer</dcterms:audience>' +
+        '<dkdcplus:version>2. oplag (2001)</dkdcplus:version>' +
+        '<dc:publisher>Gyldendal</dc:publisher>' +
+        '<dc:date>1996</dc:date>' +
+        '<dc:type xsi:type="dkdcplus:BibDK-Type">Bog</dc:type>' +
+        '<dc:format>illustreret</dc:format>' +
+        '<dcterms:extent>400 sider</dcterms:extent>' +
+        '<dc:identifier xsi:type="dkdcplus:ISBN">87-00-26818-6</dc:identifier>' +
+        '<dc:source>The Golden compass</dc:source>' +
+        '<dc:language xsi:type="dcterms:ISO639-2">dan</dc:language>' +
+        '<dc:language>Dansk</dc:language>' +
+        '</dkabm:record>' +
+        '</ting:localData>';
     var commonDataString = '<empty/>';
 
     var localData = XmlUtil.fromString( localDataString );
@@ -1793,51 +1794,51 @@ UnitTest.addFixture( "ManifestationInfo.getPriorityKeys", function() {
 
     localDataString = '<empty/>';
     commonDataString = '<ting:container' +
-            ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
-            ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-            ' xmlns:dcterms="http://purl.org/dc/terms/"' +
-            ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
-            ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
-            ' xmlns:docbook="http://docbook.org/ns/docbook"' +
-            ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
-            ' xmlns:ting="http://www.dbc.dk/ting"' +
-            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dkabm:record>' +
-            '<ac:identifier>21496782|870970</ac:identifier>' +
-            '<ac:source>Bibliotekskatalog</ac:source>' +
-            '<dc:title>Det gyldne kompas</dc:title>' +
-            '<dc:title xsi:type="dkdcplus:full">Det gyldne kompas</dc:title>' +
-            '<dc:creator xsi:type="dkdcplus:aut">Philip Pullman</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Pullman, Philip</dc:creator>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">Arktis</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">England</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">Norge</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DK5-Text">Skønlitteratur</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">det gode</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">det onde</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCO">fantasy</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:genre">fantasy</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 12 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 13 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 14 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">parallelle verdener</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DK5">sk</dc:subject>' +
-            '<dcterms:abstract>Fantasy. Lyra - 11 år og forældreløs - kommer på sporet af noget mystisk og uhyggeligt, da flere og flere børn forsvinder. Løsningen findes måske højt mod nord, mellem panserbjørne og flyvende hekse</dcterms:abstract>' +
-            '<dc:description xsi:type="dkdcplus:series">Samhørende: Det gyldne kompas ; Skyggernes kniv ; Ravkikkerten</dc:description>' +
-            '<dcterms:audience xsi:type="dkdcplus:age">fra 12 år</dcterms:audience>' +
-            '<dcterms:audience>børnematerialer</dcterms:audience>' +
-            '<dkdcplus:version>2. oplag (2001)</dkdcplus:version>' +
-            '<dc:publisher>Gyldendal</dc:publisher>' +
-            '<dc:date>1996</dc:date>' +
-            '<dc:type xsi:type="dkdcplus:BibDK-Type">Bog</dc:type>' +
-            '<dc:format>illustreret</dc:format>' +
-            '<dcterms:extent>400 sider</dcterms:extent>' +
-            '<dc:identifier xsi:type="dkdcplus:ISBN">87-00-26818-6</dc:identifier>' +
-            '<dc:source>The Golden compass</dc:source>' +
-            '<dc:language xsi:type="dcterms:ISO639-2">dan</dc:language>' +
-            '<dc:language>Dansk</dc:language>' +
-            '</dkabm:record>' +
-            '</ting:container>';
+        ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:dcterms="http://purl.org/dc/terms/"' +
+        ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
+        ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
+        ' xmlns:docbook="http://docbook.org/ns/docbook"' +
+        ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
+        ' xmlns:ting="http://www.dbc.dk/ting"' +
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+        '<dkabm:record>' +
+        '<ac:identifier>21496782|870970</ac:identifier>' +
+        '<ac:source>Bibliotekskatalog</ac:source>' +
+        '<dc:title>Det gyldne kompas</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Det gyldne kompas</dc:title>' +
+        '<dc:creator xsi:type="dkdcplus:aut">Philip Pullman</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Pullman, Philip</dc:creator>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">Arktis</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">England</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">Norge</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DK5-Text">Skønlitteratur</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">det gode</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">det onde</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCO">fantasy</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:genre">fantasy</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 12 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 13 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 14 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">parallelle verdener</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DK5">sk</dc:subject>' +
+        '<dcterms:abstract>Fantasy. Lyra - 11 år og forældreløs - kommer på sporet af noget mystisk og uhyggeligt, da flere og flere børn forsvinder. Løsningen findes måske højt mod nord, mellem panserbjørne og flyvende hekse</dcterms:abstract>' +
+        '<dc:description xsi:type="dkdcplus:series">Samhørende: Det gyldne kompas ; Skyggernes kniv ; Ravkikkerten</dc:description>' +
+        '<dcterms:audience xsi:type="dkdcplus:age">fra 12 år</dcterms:audience>' +
+        '<dcterms:audience>børnematerialer</dcterms:audience>' +
+        '<dkdcplus:version>2. oplag (2001)</dkdcplus:version>' +
+        '<dc:publisher>Gyldendal</dc:publisher>' +
+        '<dc:date>1996</dc:date>' +
+        '<dc:type xsi:type="dkdcplus:BibDK-Type">Bog</dc:type>' +
+        '<dc:format>illustreret</dc:format>' +
+        '<dcterms:extent>400 sider</dcterms:extent>' +
+        '<dc:identifier xsi:type="dkdcplus:ISBN">87-00-26818-6</dc:identifier>' +
+        '<dc:source>The Golden compass</dc:source>' +
+        '<dc:language xsi:type="dcterms:ISO639-2">dan</dc:language>' +
+        '<dc:language>Dansk</dc:language>' +
+        '</dkabm:record>' +
+        '</ting:container>';
 
     localData = XmlUtil.fromString( localDataString );
     commonData = XmlUtil.fromString( commonDataString );
@@ -1851,98 +1852,98 @@ UnitTest.addFixture( "ManifestationInfo.getPriorityKeys", function() {
     Assert.equalValue( "get priority-keys from common stream ", ManifestationInfo.getPriorityKeys( commonData, localData ), expected );
 
 
-    var localDataString = '<ting:localData' +
-            ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
-            ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-            ' xmlns:dcterms="http://purl.org/dc/terms/"' +
-            ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
-            ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
-            ' xmlns:docbook="http://docbook.org/ns/docbook"' +
-            ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
-            ' xmlns:ting="http://www.dbc.dk/ting"' +
-            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dkabm:record>' +
-            '<ac:identifier>21496782|870970</ac:identifier>' +
-            '<ac:source>Bibliotekskatalog</ac:source>' +
-            '<dc:title>Det gyldne kompas</dc:title>' +
-            '<dc:title xsi:type="dkdcplus:full">Det gyldne kompas</dc:title>' +
-            '<dc:creator xsi:type="dkdcplus:aut">Philip Pullman</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Pullman, Philip</dc:creator>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">Arktis</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">England</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">Norge</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DK5-Text">Skønlitteratur</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">det gode</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">det onde</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCO">fantasy</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:genre">fantasy</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 12 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 13 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 14 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">parallelle verdener</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DK5">sk</dc:subject>' +
-            '<dcterms:abstract>Fantasy. Lyra - 11 år og forældreløs - kommer på sporet af noget mystisk og uhyggeligt, da flere og flere børn forsvinder. Løsningen findes måske højt mod nord, mellem panserbjørne og flyvende hekse</dcterms:abstract>' +
-            '<dc:description xsi:type="dkdcplus:series">Samhørende: Det gyldne kompas ; Skyggernes kniv ; Ravkikkerten</dc:description>' +
-            '<dcterms:audience xsi:type="dkdcplus:age">fra 12 år</dcterms:audience>' +
-            '<dcterms:audience>børnematerialer</dcterms:audience>' +
-            '<dkdcplus:version>2. oplag (2001)</dkdcplus:version>' +
-            '<dc:publisher>Gyldendal</dc:publisher>' +
-            '<dc:date>1996</dc:date>' +
-            '<dc:type xsi:type="dkdcplus:BibDK-Type">Bog</dc:type>' +
-            '<dc:format>illustreret</dc:format>' +
-            '<dcterms:extent>400 sider</dcterms:extent>' +
-            '<dc:identifier xsi:type="dkdcplus:ISBN">87-00-26818-6</dc:identifier>' +
-            '<dc:source>The Golden compass</dc:source>' +
-            '<dc:language xsi:type="dcterms:ISO639-2">dan</dc:language>' +
-            '<dc:language>Dansk</dc:language>' +
-            '</dkabm:record>' +
-            '</ting:localData>';
+    localDataString = '<ting:localData' +
+        ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:dcterms="http://purl.org/dc/terms/"' +
+        ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
+        ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
+        ' xmlns:docbook="http://docbook.org/ns/docbook"' +
+        ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
+        ' xmlns:ting="http://www.dbc.dk/ting"' +
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+        '<dkabm:record>' +
+        '<ac:identifier>21496782|870970</ac:identifier>' +
+        '<ac:source>Bibliotekskatalog</ac:source>' +
+        '<dc:title>Det gyldne kompas</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Det gyldne kompas</dc:title>' +
+        '<dc:creator xsi:type="dkdcplus:aut">Philip Pullman</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Pullman, Philip</dc:creator>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">Arktis</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">England</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">Norge</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DK5-Text">Skønlitteratur</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">det gode</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">det onde</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCO">fantasy</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:genre">fantasy</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 12 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 13 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 14 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">parallelle verdener</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DK5">sk</dc:subject>' +
+        '<dcterms:abstract>Fantasy. Lyra - 11 år og forældreløs - kommer på sporet af noget mystisk og uhyggeligt, da flere og flere børn forsvinder. Løsningen findes måske højt mod nord, mellem panserbjørne og flyvende hekse</dcterms:abstract>' +
+        '<dc:description xsi:type="dkdcplus:series">Samhørende: Det gyldne kompas ; Skyggernes kniv ; Ravkikkerten</dc:description>' +
+        '<dcterms:audience xsi:type="dkdcplus:age">fra 12 år</dcterms:audience>' +
+        '<dcterms:audience>børnematerialer</dcterms:audience>' +
+        '<dkdcplus:version>2. oplag (2001)</dkdcplus:version>' +
+        '<dc:publisher>Gyldendal</dc:publisher>' +
+        '<dc:date>1996</dc:date>' +
+        '<dc:type xsi:type="dkdcplus:BibDK-Type">Bog</dc:type>' +
+        '<dc:format>illustreret</dc:format>' +
+        '<dcterms:extent>400 sider</dcterms:extent>' +
+        '<dc:identifier xsi:type="dkdcplus:ISBN">87-00-26818-6</dc:identifier>' +
+        '<dc:source>The Golden compass</dc:source>' +
+        '<dc:language xsi:type="dcterms:ISO639-2">dan</dc:language>' +
+        '<dc:language>Dansk</dc:language>' +
+        '</dkabm:record>' +
+        '</ting:localData>';
     commonDataString = '<ting:container' +
-            ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
-            ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-            ' xmlns:dcterms="http://purl.org/dc/terms/"' +
-            ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
-            ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
-            ' xmlns:docbook="http://docbook.org/ns/docbook"' +
-            ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
-            ' xmlns:ting="http://www.dbc.dk/ting"' +
-            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dkabm:record>' +
-            '<ac:identifier>not-really-this</ac:identifier>' +
-            '<ac:source>Bibliotekskatalog</ac:source>' +
-            '<dc:title>Det gyldne kompas</dc:title>' +
-            '<dc:title xsi:type="dkdcplus:full">Det gyldne kompas</dc:title>' +
-            '<dc:creator xsi:type="dkdcplus:aut">Philip Pullman</dc:creator>' +
-            '<dc:creator xsi:type="oss:sort">Pullman, Philip</dc:creator>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">Arktis</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">England</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">Norge</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DK5-Text">Skønlitteratur</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">det gode</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">det onde</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCO">fantasy</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:genre">fantasy</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 12 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 13 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCN">for 14 år</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DBCS">parallelle verdener</dc:subject>' +
-            '<dc:subject xsi:type="dkdcplus:DK5">sk</dc:subject>' +
-            '<dcterms:abstract>Fantasy. Lyra - 11 år og forældreløs - kommer på sporet af noget mystisk og uhyggeligt, da flere og flere børn forsvinder. Løsningen findes måske højt mod nord, mellem panserbjørne og flyvende hekse</dcterms:abstract>' +
-            '<dc:description xsi:type="dkdcplus:series">Samhørende: Det gyldne kompas ; Skyggernes kniv ; Ravkikkerten</dc:description>' +
-            '<dcterms:audience xsi:type="dkdcplus:age">fra 12 år</dcterms:audience>' +
-            '<dcterms:audience>børnematerialer</dcterms:audience>' +
-            '<dkdcplus:version>0. oplag (1811)</dkdcplus:version>' +
-            '<dc:publisher>Gyldendal</dc:publisher>' +
-            '<dc:date>1747</dc:date>' +
-            '<dc:type xsi:type="dkdcplus:BibDK-Type">Bog</dc:type>' +
-            '<dc:format>illustreret</dc:format>' +
-            '<dcterms:extent>400 sider</dcterms:extent>' +
-            '<dc:identifier xsi:type="dkdcplus:ISBN">87-00-26818-6</dc:identifier>' +
-            '<dc:source>The Golden compass</dc:source>' +
-            '<dc:language xsi:type="dcterms:ISO639-2">dan</dc:language>' +
-            '<dc:language>Dansk</dc:language>' +
-            '</dkabm:record>' +
-            '</ting:container>';
+        ' xmlns:ac="http://biblstandard.dk/ac/namespace/"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:dcterms="http://purl.org/dc/terms/"' +
+        ' xmlns:dkabm="http://biblstandard.dk/abm/namespace/dkabm/"' +
+        ' xmlns:dkdcplus="http://biblstandard.dk/abm/namespace/dkdcplus/"' +
+        ' xmlns:docbook="http://docbook.org/ns/docbook"' +
+        ' xmlns:oss="http://oss.dbc.dk/ns/osstypes"' +
+        ' xmlns:ting="http://www.dbc.dk/ting"' +
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+        '<dkabm:record>' +
+        '<ac:identifier>not-really-this</ac:identifier>' +
+        '<ac:source>Bibliotekskatalog</ac:source>' +
+        '<dc:title>Det gyldne kompas</dc:title>' +
+        '<dc:title xsi:type="dkdcplus:full">Det gyldne kompas</dc:title>' +
+        '<dc:creator xsi:type="dkdcplus:aut">Philip Pullman</dc:creator>' +
+        '<dc:creator xsi:type="oss:sort">Pullman, Philip</dc:creator>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">Arktis</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">England</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">Norge</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DK5-Text">Skønlitteratur</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">det gode</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">det onde</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCO">fantasy</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:genre">fantasy</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 12 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 13 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCN">for 14 år</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DBCS">parallelle verdener</dc:subject>' +
+        '<dc:subject xsi:type="dkdcplus:DK5">sk</dc:subject>' +
+        '<dcterms:abstract>Fantasy. Lyra - 11 år og forældreløs - kommer på sporet af noget mystisk og uhyggeligt, da flere og flere børn forsvinder. Løsningen findes måske højt mod nord, mellem panserbjørne og flyvende hekse</dcterms:abstract>' +
+        '<dc:description xsi:type="dkdcplus:series">Samhørende: Det gyldne kompas ; Skyggernes kniv ; Ravkikkerten</dc:description>' +
+        '<dcterms:audience xsi:type="dkdcplus:age">fra 12 år</dcterms:audience>' +
+        '<dcterms:audience>børnematerialer</dcterms:audience>' +
+        '<dkdcplus:version>0. oplag (1811)</dkdcplus:version>' +
+        '<dc:publisher>Gyldendal</dc:publisher>' +
+        '<dc:date>1747</dc:date>' +
+        '<dc:type xsi:type="dkdcplus:BibDK-Type">Bog</dc:type>' +
+        '<dc:format>illustreret</dc:format>' +
+        '<dcterms:extent>400 sider</dcterms:extent>' +
+        '<dc:identifier xsi:type="dkdcplus:ISBN">87-00-26818-6</dc:identifier>' +
+        '<dc:source>The Golden compass</dc:source>' +
+        '<dc:language xsi:type="dcterms:ISO639-2">dan</dc:language>' +
+        '<dc:language>Dansk</dc:language>' +
+        '</dkabm:record>' +
+        '</ting:container>';
 
     localData = XmlUtil.fromString( localDataString );
     commonData = XmlUtil.fromString( commonDataString );

--- a/javascript/src/main/resources/javascript/ManifestationInfo.use.js
+++ b/javascript/src/main/resources/javascript/ManifestationInfo.use.js
@@ -159,27 +159,27 @@ var ManifestationInfo = (function() {
 
         //first check if localData has a full title
         var series = XPath.selectText( '/ting:localData/dkabm:record/dc:title[@xsi:type="dkdcplus:series"]', localData );
-        Log.trace("local title=", series);
+        Log.trace( "local title=", series );
         series = series.trim();
         var split = true;
 
         if ( "" === series ) {
             series = XPath.selectText( '/ting:localData/dkabm:record/dc:description[@xsi:type="dkdcplus:series"]', localData );
-            Log.trace("local desc=", series);
+            Log.trace( "local desc=", series );
             series = series.trim();
             split = false;
         }
 
         if ( "" === series ) {
             series = XPath.selectText( '/ting:container/dkabm:record/dc:title[@xsi:type="dkdcplus:series"]', commonData );
-            Log.trace("common title=", series);
+            Log.trace( "common title=", series );
             series = series.trim();
             split = true;
         }
 
         if ( "" === series ) {
             series = XPath.selectText( '/ting:container/dkabm:record/dc:description[@xsi:type="dkdcplus:series"]', commonData );
-            Log.trace("common desc=", series);
+            Log.trace( "common desc=", series );
             series = series.trim();
             split = false;
         }
@@ -193,11 +193,11 @@ var ManifestationInfo = (function() {
         var seriesTitle = series;
         var seriesInstalment = null;
 
-        if(split) {
+        if ( split ) {
             var instalmentMatch = series.match( '^(.+) ; (.+)$' );
             if ( instalmentMatch !== null ) {
-                seriesTitle = instalmentMatch[1];
-                seriesInstalment = instalmentMatch[2];
+                seriesTitle = instalmentMatch[ 1 ];
+                seriesInstalment = instalmentMatch[ 2 ];
             }
         }
 
@@ -233,8 +233,8 @@ var ManifestationInfo = (function() {
 
         for ( var i in creators ) {
 
-            var type = XmlUtil.getAttribute( creators[i], "type", XmlNamespaces.xsi );
-            var value = XmlUtil.getText( creators[i] ).trim();
+            var type = XmlUtil.getAttribute( creators[ i ], "type", XmlNamespaces.xsi );
+            var value = XmlUtil.getText( creators[ i ] ).trim();
 
             if ( type === undefined ) {
                 type = null;
@@ -250,7 +250,7 @@ var ManifestationInfo = (function() {
                 Log.warn( "ManifestationInfo.getSubjects type is: " + type );
             }
 
-            creators[i] = {
+            creators[ i ] = {
                 "type": type,
                 "value": value
             };
@@ -365,8 +365,8 @@ var ManifestationInfo = (function() {
         }
         for ( var i in subjects ) {
 
-            var type = XmlUtil.getAttribute( subjects[i], "type", XmlNamespaces.xsi );
-            var value = XmlUtil.getText( subjects[i] ).trim();
+            var type = XmlUtil.getAttribute( subjects[ i ], "type", XmlNamespaces.xsi );
+            var value = XmlUtil.getText( subjects[ i ] ).trim();
 
             if ( type === undefined ) {
                 type = null;
@@ -379,7 +379,7 @@ var ManifestationInfo = (function() {
                 Log.warn( "ManifestationInfo.getSubjects type is: " + type );
             }
 
-            subjects[i] = {
+            subjects[ i ] = {
                 "type": type,
                 "value": value
             };

--- a/javascript/src/main/resources/javascript/ManifestationInfo.use.js
+++ b/javascript/src/main/resources/javascript/ManifestationInfo.use.js
@@ -34,6 +34,7 @@ var ManifestationInfo = (function() {
                 "description": null, //from commonData stream dcterms:abstract - string, null if no data
                 "subjects": [], //from common and local stream if subject element present, array, empty array if no data
                 "types": [], //from DC stream, array, must be present
+                "workTypes": [], //from commonData stream adminData workType, array, must be present
                 "priorityKeys": {} //from DC stream for determining owner of the work, must be present
             };
 
@@ -58,6 +59,7 @@ var ManifestationInfo = (function() {
         manifestationObject.description = getAbstract( commonDataXml, localDataXml );
         manifestationObject.subjects = getSubjects( commonDataXml, localDataXml );
         manifestationObject.types = getTypes( dcStreamXml );
+        manifestationObject.workTypes = getWorkTypes( commonDataXml );
         manifestationObject.priorityKeys = getPriorityKeys( commonDataXml, localDataXml );
 
         Log.trace( "Leaving: ManifestationInfo.getManifestationInfoFromXmlObjects function" );
@@ -306,6 +308,33 @@ var ManifestationInfo = (function() {
     }
 
     /**
+     * Function that extracts workTypes from the provided common data stream
+     *
+     * @type {function}
+     * @syntax ManifestationInfo.getWorkTypes( commonData )
+     * @param {Document} commonData the common data stream as xml
+     * @return {Array} the extracted work types
+     * @function
+     * @name ManifestationInfo.getWorkTypes
+     */
+
+    function getWorkTypes( commonData ) {
+
+        Log.trace( "Entering: ManifestationInfo.getWorkTypes function" );
+
+        var workTypes = XPath.selectMultipleText( "/ting:container/adminData/workType", commonData );
+
+        if ( 0 === workTypes.length ) {
+            RecordProcessing.terminateProcessingAndFailRecord(
+                "ManifestationInfo.getWorkTypes no workType was found in adminData in common stream" );
+        }
+
+        Log.trace( "Leaving: ManifestationInfo.getWorkTypes function" );
+
+        return workTypes;
+    }
+
+    /**
      * Function that extracts the abstract from the either the local data stream
      * or if not present there the common data stream
      *
@@ -492,6 +521,7 @@ var ManifestationInfo = (function() {
         getSeries: getSeries,
         getCreators: getCreators,
         getTypes: getTypes,
+        getWorkTypes: getWorkTypes,
         getAbstract: getAbstract,
         getSubjects: getSubjects,
         getPriorityKeys: getPriorityKeys

--- a/javascript/src/test/resources/accept-test/example/expected.json
+++ b/javascript/src/test/resources/accept-test/example/expected.json
@@ -19,5 +19,6 @@
         "date": "1972",
         "version": "2. udgave"
     },
-    "types": [ "Bog" ]
+    "types": [ "Bog" ],
+    "workTypes": [ "literature" ]
 }

--- a/javascript/src/test/resources/accept-test/harrypotter/expected.json
+++ b/javascript/src/test/resources/accept-test/harrypotter/expected.json
@@ -25,5 +25,6 @@
         "date": "1999",
         "version": null
     },
-    "types": [ "Bog" ]
+    "types": [ "Bog" ],
+    "workTypes": [ "literature"]
 }

--- a/javascript/src/test/resources/accept-test/koraan-empty-local-data/expected.json
+++ b/javascript/src/test/resources/accept-test/koraan-empty-local-data/expected.json
@@ -12,5 +12,6 @@
     "version" : null
   },
   "pid" : "koraan-empty-local-data",
-  "types" : [ "Bog" ]
+  "types" : [ "Bog" ],
+  "workTypes" : [ "literature" ]
 }

--- a/javascript/src/test/resources/accept-test/vildheks/expected.json
+++ b/javascript/src/test/resources/accept-test/vildheks/expected.json
@@ -33,5 +33,6 @@
         "date": "2010",
         "version": "1. udgave, 11. oplag (2018)"
     },
-    "types": [ "Bog" ]
+    "types": [ "Bog" ],
+    "workTypes": [ "literature" ]
 }

--- a/service/src/main/java/dk/dbc/search/work/presentation/service/response/WorkInformationResponse.java
+++ b/service/src/main/java/dk/dbc/search/work/presentation/service/response/WorkInformationResponse.java
@@ -20,7 +20,6 @@ package dk.dbc.search.work.presentation.service.response;
 
 import dk.dbc.search.work.presentation.api.pojo.WorkInformation;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.Collections;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import java.util.List;

--- a/service/src/main/java/dk/dbc/search/work/presentation/service/response/WorkInformationResponse.java
+++ b/service/src/main/java/dk/dbc/search/work/presentation/service/response/WorkInformationResponse.java
@@ -20,6 +20,7 @@ package dk.dbc.search.work.presentation.service.response;
 
 import dk.dbc.search.work.presentation.api.pojo.WorkInformation;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Collections;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import java.util.List;
@@ -60,6 +61,9 @@ public class WorkInformationResponse {
     @Schema(implementation = TypedValueResponse.Array.class)
     public Set<TypedValueResponse> subjects;
 
+    @Schema(example = "literature", implementation = String.class)
+    public Set<String> workTypes;
+
     @Schema(implementation = GroupInformationResponse.Array.class, description = "The first entry in the list is the representative group for this work, the rest are in random order")
     public List<GroupInformationResponse> groups;
 
@@ -81,6 +85,7 @@ public class WorkInformationResponse {
         wir.subjects = wi.subjects.stream()
                 .map(TypedValueResponse::from)
                 .collect(Collectors.toSet());
+        wir.workTypes = wi.workTypes == null ? null : wi.workTypes.stream().collect(Collectors.toSet());
         // wir.records is computed in FilterResult.processWork()
         return wir;
     }
@@ -99,12 +104,13 @@ public class WorkInformationResponse {
                Objects.equals(creators, that.creators) &&
                Objects.equals(description, that.description) &&
                Objects.equals(subjects, that.subjects) &&
+               Objects.equals(workTypes, that.workTypes) &&
                Objects.equals(groups, that.groups);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(workId, title, fullTitle, series, creators, description, subjects, groups);
+        return Objects.hash(workId, title, fullTitle, series, creators, description, subjects, workTypes, groups);
     }
 
     @Override

--- a/service/src/test/resources/WorkPresentationBean/simple-filter/expected.json
+++ b/service/src/test/resources/WorkPresentationBean/simple-filter/expected.json
@@ -6,6 +6,7 @@
         { "type": "aut", "value": "yrjö kilpinen" }
     ],
     "subjects": [ ],
+    "workTypes": [ "literature" ],
     "groups": [
         {
             "relations": [ ],

--- a/service/src/test/resources/WorkPresentationBean/simple-filter/source.json
+++ b/service/src/test/resources/WorkPresentationBean/simple-filter/source.json
@@ -89,5 +89,6 @@
         "unit:7892641": [ ]
     },
     "subjects": [ ],
+    "workTypes": [ "literature" ],
     "fullTitle": "Fjeldsange : for 1 stemme og klaver"
 }

--- a/worker/src/main/java/dk/dbc/search/work/presentation/worker/WorkConsolidator.java
+++ b/worker/src/main/java/dk/dbc/search/work/presentation/worker/WorkConsolidator.java
@@ -190,6 +190,7 @@ public class WorkConsolidator {
         work.fullTitle = primary.fullTitle;
         work.series = null;
         work.title = primary.title;
+        work.workTypes = primary.workTypes;
 
         // Map into unit->manifestations and unit->relationType->relationManifestation
         work.dbUnitInformation = new HashMap<>();

--- a/worker/src/test/java/dk/dbc/search/work/presentation/worker/WorkConsolidatorTest.java
+++ b/worker/src/test/java/dk/dbc/search/work/presentation/worker/WorkConsolidatorTest.java
@@ -102,7 +102,7 @@ public class WorkConsolidatorTest {
             O.writeValue(dir.resolve("actual.json").toFile(), actual);
         }
 
-        assertThat(actual, is(expected));
+        assertThat("testBuildWorkInformation: " + directory.getName(), actual, is(expected));
     }
 
     Source readSource(File sourceFile) throws IOException {

--- a/worker/src/test/resources/WorkConsolidator/multiple-manifestations/expected.json
+++ b/worker/src/test/resources/WorkConsolidator/multiple-manifestations/expected.json
@@ -16,9 +16,13 @@
             "type": "KW",
             "value": "elephants"
         } ],
+    "workTypes": [
+    ],
     "dbUnits": {
         "unit:1": [ {
-                "pid": "870970-basis:0"
+                "pid": "870970-basis:0",
+                "workTypes": [
+                ]
             }, {
                 "pid": "710100-katalog:0"
             } ]

--- a/worker/src/test/resources/WorkConsolidator/multiple-manifestations/source.json
+++ b/worker/src/test/resources/WorkConsolidator/multiple-manifestations/source.json
@@ -7,6 +7,7 @@
                     "title": "Two Things",
                     "creators": [ { "type": "aut", "value": "Me" } ],
                     "subjects": [ { "type": "KW", "value": "mice"}, { "type": "KW", "value": "men"} ],
+                    "workTypes": [],
                     "priorityKeys": {
                         "identifier": "xx|000000",
                         "date": "2020"

--- a/worker/src/test/resources/WorkConsolidator/multiple-objects/expected.json
+++ b/worker/src/test/resources/WorkConsolidator/multiple-objects/expected.json
@@ -16,11 +16,20 @@
             "type": "KW",
             "value": "elephants"
         } ],
+    "workTypes": [
+        "wa"
+    ],
     "dbUnits": {
         "unit:1": [ {
-                "pid": "870970-basis:0"
+                "pid": "870970-basis:0",
+                "workTypes": [
+                    "wa"
+                ]
             }, {
-                "pid": "870970-basis:1"
+                "pid": "870970-basis:1",
+                "workTypes": [
+                    "wb"
+                ]
             } ]
     },
     "dbRelUnits": {

--- a/worker/src/test/resources/WorkConsolidator/multiple-objects/source.json
+++ b/worker/src/test/resources/WorkConsolidator/multiple-objects/source.json
@@ -7,6 +7,7 @@
                     "title": "Two Things",
                     "creators": [ { "type": "aut", "value": "Me" } ],
                     "subjects": [ { "type": "KW", "value": "mice"}, { "type": "KW", "value": "men"} ],
+                    "workTypes": [ "wa" ],
                     "priorityKeys": {
                         "identifier": "xx|000000",
                         "date": "2020"
@@ -18,6 +19,7 @@
                     "title": "Two Things",
                     "creators": [ { "type": "aut", "value": "Me" }, { "type": "aut", "value": "You" } ],
                     "subjects": [ { "type": "KW", "value": "mice"}, { "type": "KW", "value": "elephants"} ],
+                    "workTypes": [ "wb" ],
                     "priorityKeys": {
                         "identifier": "xx|000000",
                         "date": "2020"

--- a/worker/src/test/resources/WorkConsolidator/simple/expected.json
+++ b/worker/src/test/resources/WorkConsolidator/simple/expected.json
@@ -13,9 +13,15 @@
     "type" : "KW",
     "value" : "men"
   } ],
+  "workTypes": [
+    "wa", "wb"
+  ],
   "dbUnits" : {
     "unit:1" : [ {
-      "pid" : "870970-basis:0"
+      "pid" : "870970-basis:0",
+      "workTypes": [
+        "wa", "wb"
+      ]
     } ]
   },
   "dbRelUnits" : {

--- a/worker/src/test/resources/WorkConsolidator/simple/source.json
+++ b/worker/src/test/resources/WorkConsolidator/simple/source.json
@@ -7,6 +7,7 @@
                     "title": "Two Things",
                     "creators": [ { "type": "aut", "value": "Me" } ],
                     "subjects": [ { "type": "KW", "value": "mice"}, { "type": "KW", "value": "men"} ],
+                    "workTypes": [ "wa", "wb" ],
                     "priorityKeys": {
                         "identifier": "xx|000000",
                         "date": "2020"


### PR DESCRIPTION

Tested with local database and content from production:

```
curl -s 'http://localhost:8080/api/work-presentation?workId=work-of%3A870970-basis%3A23645564&agencyId=190101&profile=default&includeRelations=false' | jq .work.workTypes
[
  "literature"
]
```